### PR TITLE
probe: verify required freshness check blocks a stale PR

### DIFF
--- a/apis/dev/planton/provider/aws/awsvpc/v1/reference.md
+++ b/apis/dev/planton/provider/aws/awsvpc/v1/reference.md
@@ -2,7 +2,6 @@
 
 > Generated from the protobuf schema by `make generate-reference` -- do not
 > edit by hand. To change a fact on this page, change the proto field comment
-> or validation rule it is derived from, then regenerate.
 
 **apiVersion**: `aws.planton.dev/v1`
 


### PR DESCRIPTION
Short-lived probe: this PR carries deliberately stale generated docs and must be hard-blocked by the required reference-freshness check. It will be closed unmerged.