### PR TITLE
docs(catalog): teach Valkey's Ray GCS-backing role and the durability flip

### DIFF
--- a/apis/dev/planton/provider/kubernetes/kubernetesvalkey/v1alpha1/GUIDE.md
+++ b/apis/dev/planton/provider/kubernetes/kubernetesvalkey/v1alpha1/GUIDE.md
@@ -31,6 +31,27 @@ adds read scaling and a warm copy, but no automated promotion: durability
 through a primary restart comes from persistence, not from replicas (the
 full story is on [reference.md](reference.md)). If losing the store's
 contents is unacceptable, persistence is the lever to reach for first.
+One composition flips this judgment outright: backing a Ray cluster's
+GCS fault tolerance (next section).
+
+## Backing Ray's GCS flips the durability call
+
+[KubernetesRayCluster](../../kubernetesraycluster/v1alpha1/GUIDE.md)
+composes this kind for GCS fault tolerance: its
+`spec.gcsFaultTolerance.redisAddress` wires to this store's exported
+`kube_endpoint`. In that role the data is NOT a cache — it is the Ray
+cluster's control state (every job, actor, and worker registration),
+externalized here precisely so it survives head-pod loss. A Valkey
+that restarts empty erases the state Ray would have recovered from:
+the fault tolerance the composition was built for is silently
+defeated, and nothing fails at apply time. So the judgment above
+flips — declare persistence (`spec.persistence`, with
+`config.appendOnly: true` for lossless restarts) even standalone, and
+leave `config.maxMemoryPolicy` at its noeviction default: evicting
+keys from a state store corrupts it as surely as losing the volume.
+Declare auth in the same manifest — Ray's `redisPasswordSecret` reads
+the `password_secret` output this kind exports when ACL users are
+declared.
 
 ## Namespace ownership
 
@@ -48,5 +69,8 @@ ACL users live inside this spec, so client identity does not add nodes.
 ## Pairs well with
 
 - KubernetesNamespace — the shared namespace's owner (pattern above).
+- KubernetesRayCluster — backs its GCS fault tolerance through the
+  exported `kube_endpoint`; the one pairing where this store must not
+  be treated as a cache (section above).
 - The application workloads that consume it, connecting through the
   exported `kube_endpoint`.


### PR DESCRIPTION
## What does this PR do?

Teaches the KubernetesValkey guide the one role where its own topology
advice inverts: backing KubernetesRayCluster's GCS fault tolerance. The
Ray guide already sends readers here (twice), but this guide never
mentions Ray — its "Pairs well with" lists only KubernetesNamespace and
generic workloads, and its topology section teaches "standalone suits
caches — data that can vanish," which is exactly the wrong default when
Valkey holds Ray's externalized control state: a Valkey that restarts
empty erases the state Ray would have recovered from, silently defeating
the fault tolerance, and nothing fails at apply time. Adds a section
teaching the flip (persist even standalone, `appendOnly`, keep
`noeviction`, declare auth for the `redisPasswordSecret` wiring) and a
"Pairs well with" entry for KubernetesRayCluster.

## Catalog knowledge routing

- [ ] Fact fixes went into proto comments / validation rules (never into
      generated `reference.md` files), and `make generate-reference` was run
      — N/A: no facts changed, no generated file touched
- [x] Component judgment went into the kind's `GUIDE.md`; composition wisdom
      went into `apis/dev/planton/provider/patterns/`
- [ ] `go test ./pkg/explain/refgen/` passes (reference freshness + authored
      knowledge checks) — not run locally: contributed via the clone-free
      lane (no repo checkout); this edits an existing GUIDE.md only, so no
      generated output changes and CI's run of this check is the gate

## How was this tested?

No repo toolchain was available (clone-free contribution). Verification
done instead:

- Every claim grounded in the generated pages: the Ray reference's
  state-truth paragraph (GCS holds all job/actor/worker state in memory;
  compose a KubernetesValkey); the Valkey reference's Referenced By table
  (`KubernetesRayCluster spec.gcsFaultTolerance.redisAddress` reads
  `status.outputs.kube_endpoint`; `redisPasswordSecret.name` reads
  `status.outputs.password_secret.name`); the Valkey reference's field
  docs (standalone persistence optional — "starts empty after every pod
  restart"; `appendOnly` makes restarts lossless with a volume;
  `noeviction` is the server default, "right for durable stores").
- The edited file was diffed against `main` via the GitHub API before
  drafting: identical, so the diff applies cleanly.
- The one new relative link resolves within the tree (mirrors the Ray
  guide's existing reverse link).
- CI's authored-knowledge checks validate links and placement on this PR.

Drafted by an AI agent following the multi-cloud-catalog skill's
contribution workflow; reviewed and submitted with the user's approval.
