### PR TITLE
fix(aws): one pessimistic provider pin (~> 6.58) across all 112 catalog modules

### DIFF
--- a/catalog/aws/awsalb/iac/tf/provider.tf
+++ b/catalog/aws/awsalb/iac/tf/provider.tf
@@ -1,8 +1,14 @@
 terraform {
   required_providers {
     aws = {
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsapprunnerautoscalingconfiguration/iac/tf/provider.tf
+++ b/catalog/aws/awsapprunnerautoscalingconfiguration/iac/tf/provider.tf
@@ -2,12 +2,19 @@ terraform {
   required_version = ">= 1.0"
   required_providers {
     aws = {
-      # Family floor: the App Runner family pins the v6 line so every
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor (family baseline): the App Runner family pins the v6 line so every
       # sibling (service, VPC connector, observability configuration)
       # resolves from the same provider build; the resources themselves
       # predate v6.
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsapprunnerobservabilityconfiguration/iac/tf/provider.tf
+++ b/catalog/aws/awsapprunnerobservabilityconfiguration/iac/tf/provider.tf
@@ -2,12 +2,19 @@ terraform {
   required_version = ">= 1.0"
   required_providers {
     aws = {
-      # Family floor: the App Runner family pins the v6 line so every
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor (family baseline): the App Runner family pins the v6 line so every
       # sibling (service, VPC connector, auto scaling configuration)
       # resolves from the same provider build; the resources themselves
       # predate v6.
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsapprunnerservice/iac/tf/provider.tf
+++ b/catalog/aws/awsapprunnerservice/iac/tf/provider.tf
@@ -2,12 +2,19 @@ terraform {
   required_version = ">= 1.0"
   required_providers {
     aws = {
-      # Family floor: the App Runner family pins the v6 line so every
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor (family baseline): the App Runner family pins the v6 line so every
       # sibling (VPC connector, auto scaling configuration, observability
       # configuration) resolves from the same provider build; the service
       # resource itself predates v6.
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsapprunnervpcconnector/iac/tf/provider.tf
+++ b/catalog/aws/awsapprunnervpcconnector/iac/tf/provider.tf
@@ -2,12 +2,19 @@ terraform {
   required_version = ">= 1.0"
   required_providers {
     aws = {
-      # Family floor: the App Runner family pins the v6 line so every
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor (family baseline): the App Runner family pins the v6 line so every
       # sibling (service, auto scaling configuration, observability
       # configuration) resolves from the same provider build; the resources
       # themselves predate v6.
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsathenaworkgroup/iac/tf/provider.tf
+++ b/catalog/aws/awsathenaworkgroup/iac/tf/provider.tf
@@ -3,11 +3,18 @@ terraform {
 
   required_providers {
     aws = {
-      # Floor 6.34.0: the workgroup's query_results_s3_access_grants_configuration
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor 6.34.0: the workgroup's query_results_s3_access_grants_configuration
       # lands there (identity_center 6.7.0, managed_query_results 6.25.0, and
       # monitoring_configuration 6.28.0 are all below the floor).
       source  = "hashicorp/aws"
-      version = ">= 6.34.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsautoscalinggroup/iac/tf/provider.tf
+++ b/catalog/aws/awsautoscalinggroup/iac/tf/provider.tf
@@ -1,8 +1,14 @@
 terraform {
   required_providers {
     aws = {
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsbatchcomputeenvironment/iac/tf/provider.tf
+++ b/catalog/aws/awsbatchcomputeenvironment/iac/tf/provider.tf
@@ -1,12 +1,19 @@
 terraform {
   required_providers {
     aws = {
-      # v6 family floor: the Batch compute-environment surface (including
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor (v6 family baseline): the Batch compute-environment surface (including
       # eks_configuration, ec2_configuration.image_kubernetes_version, and
       # update_policy) is stable before the v6 line; the floor keeps the
       # Batch family on one provider generation.
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsbatchjobdefinition/iac/tf/provider.tf
+++ b/catalog/aws/awsbatchjobdefinition/iac/tf/provider.tf
@@ -1,12 +1,19 @@
 terraform {
   required_providers {
     aws = {
-      # v6 family floor: the job-definition surface (containerProperties
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor (v6 family baseline): the job-definition surface (containerProperties
       # incl. runtimePlatform and ephemeralStorage, deregister_on_new_revision)
       # is stable before the v6 line; the floor keeps the Batch family on
       # one provider generation.
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsbatchjobqueue/iac/tf/provider.tf
+++ b/catalog/aws/awsbatchjobqueue/iac/tf/provider.tf
@@ -1,11 +1,18 @@
 terraform {
   required_providers {
     aws = {
-      # v6 family floor: the job-queue surface (compute_environment_order,
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor (v6 family baseline): the job-queue surface (compute_environment_order,
       # job_state_time_limit_action) is stable before the v6 line; the floor
       # keeps the Batch family on one provider generation.
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsbatchschedulingpolicy/iac/tf/provider.tf
+++ b/catalog/aws/awsbatchschedulingpolicy/iac/tf/provider.tf
@@ -1,11 +1,18 @@
 terraform {
   required_providers {
     aws = {
-      # v6 family floor: the scheduling-policy surface (fair_share_policy)
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor (v6 family baseline): the scheduling-policy surface (fair_share_policy)
       # is stable before the v6 line; the floor keeps the Batch family on
       # one provider generation.
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awscertmanagercert/iac/tf/provider.tf
+++ b/catalog/aws/awscertmanagercert/iac/tf/provider.tf
@@ -1,10 +1,17 @@
 terraform {
   required_providers {
     aws = {
-      # Floor 6.4.0: options.export (exportable certificates) landed there;
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor 6.4.0: options.export (exportable certificates) landed there;
       # everything else this module renders is older.
       source  = "hashicorp/aws"
-      version = ">= 6.4.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsclientvpn/iac/tf/provider.tf
+++ b/catalog/aws/awsclientvpn/iac/tf/provider.tf
@@ -1,13 +1,20 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      # Floor, not a cap: endpoint_ip_address_type / traffic_ip_address_type
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor: endpoint_ip_address_type / traffic_ip_address_type
       # (and client_cidr_block becoming optional for IPv6 traffic) land in
       # v6.11.0 -- an older floor would silently reject the dual-stack
       # surface. (client_route_enforcement_options and
       # disconnect_on_session_timeout predate it.)
-      version = ">= 6.11.0"
+      source  = "hashicorp/aws"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awscloudfront/iac/tf/provider.tf
+++ b/catalog/aws/awscloudfront/iac/tf/provider.tf
@@ -1,10 +1,17 @@
 terraform {
   required_providers {
     aws = {
-      # v6 family floor: everything this module renders (incl. the origin
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor (v6 family baseline): everything this module renders (incl. the origin
       # vpc_origin_config and per-behavior grpc_config blocks) predates 6.0.
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awscloudwatchalarm/iac/tf/provider.tf
+++ b/catalog/aws/awscloudwatchalarm/iac/tf/provider.tf
@@ -1,13 +1,20 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      # Floor, not a ceiling. PromQL alarms (evaluation_criteria +
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor: PromQL alarms (evaluation_criteria +
       # evaluation_interval) landed in v6.42.0, but that release shipped a
       # plan-time regression (spurious "One of 'metric_name', 'metric_query',
       # or 'evaluation_criteria' must be set" errors) fixed in v6.43.0 — so
       # the floor deliberately skips the broken release.
-      version = ">= 6.43.0"
+      source  = "hashicorp/aws"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awscloudwatchcompositealarm/iac/tf/provider.tf
+++ b/catalog/aws/awscloudwatchcompositealarm/iac/tf/provider.tf
@@ -1,11 +1,18 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      # Floor, not a ceiling: the full aws_cloudwatch_composite_alarm surface
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor: the full aws_cloudwatch_composite_alarm surface
       # (incl. actions_suppressor) is stable across the v6 line; the family
       # floor keeps sibling AWS modules on the same resolved major.
-      version = ">= 6.0.0"
+      source  = "hashicorp/aws"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awscloudwatchloggroup/iac/tf/provider.tf
+++ b/catalog/aws/awscloudwatchloggroup/iac/tf/provider.tf
@@ -1,11 +1,18 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      # Floor, not a ceiling: deletion_protection_enabled landed on
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor: deletion_protection_enabled landed on
       # aws_cloudwatch_log_group in v6.25.0. Sibling AWS modules share the v6
       # line so behavior never varies per kind.
-      version = ">= 6.25.0"
+      source  = "hashicorp/aws"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awscodebuildproject/iac/tf/provider.tf
+++ b/catalog/aws/awscodebuildproject/iac/tf/provider.tf
@@ -3,11 +3,18 @@ terraform {
 
   required_providers {
     aws = {
-      # Floor 6.16.0: the project's auto_retry_limit lands there (the
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor 6.16.0: the project's auto_retry_limit lands there (the
       # webhook's pull_request_build_policy 6.13.0, the environment's
       # docker_server 6.2.0, and everything else are below the floor).
       source  = "hashicorp/aws"
-      version = ">= 6.16.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awscodepipeline/iac/tf/provider.tf
+++ b/catalog/aws/awscodepipeline/iac/tf/provider.tf
@@ -3,12 +3,19 @@ terraform {
 
   required_providers {
     aws = {
-      # Floor 6.0.0: the whole V2 surface this module renders (pipeline_type,
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor 6.0.0: the whole V2 surface this module renders (pipeline_type,
       # execution_mode, triggers with file-path filters, per-action
       # timeout_in_minutes, and stage conditions with rules) landed on the
       # 5.x line (<= 5.93.0), so any 6.x release carries it.
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awscognitoidentityprovider/e2e/profile.yaml
+++ b/catalog/aws/awscognitoidentityprovider/e2e/profile.yaml
@@ -13,8 +13,5 @@ spec:
   # issuer); its wiring is proven by the offline gate and the SAML/OIDC CEL
   # spec tests.
   tier: 1
-  status: green
-  validated_provisioners:
-    - pulumi
-    - terraform
+  status: pending_proof
   timeout_minutes: 20

--- a/catalog/aws/awscognitoidentityprovider/iac/tf/provider.tf
+++ b/catalog/aws/awscognitoidentityprovider/iac/tf/provider.tf
@@ -1,8 +1,14 @@
 terraform {
   required_providers {
     aws = {
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
       source  = "hashicorp/aws"
-      version = "= 5.82.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awscognitoresourceserver/iac/tf/provider.tf
+++ b/catalog/aws/awscognitoresourceserver/iac/tf/provider.tf
@@ -3,10 +3,17 @@ terraform {
 
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
       # The v6 line is the family floor; the resource-server surface is
       # long-stable.
-      version = ">= 6.0.0"
+      source  = "hashicorp/aws"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awscognitouserpool/iac/tf/provider.tf
+++ b/catalog/aws/awscognitouserpool/iac/tf/provider.tf
@@ -3,12 +3,19 @@ terraform {
 
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
       # 6.11.0 is the floor for the surface this module manages: the
       # aws_cognito_log_delivery_configuration resource landed in 6.5.0 and
       # 6.11.0 fixed the provider to accept email_mfa_configuration as this
       # module sends it.
-      version = ">= 6.11.0"
+      source  = "hashicorp/aws"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awscognitouserpoolclient/iac/tf/provider.tf
+++ b/catalog/aws/awscognitouserpoolclient/iac/tf/provider.tf
@@ -3,10 +3,17 @@ terraform {
 
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
       # The v6 line is the family floor; every argument this module manages
       # (including refresh_token_rotation) is present from 6.0.0.
-      version = ">= 6.0.0"
+      source  = "hashicorp/aws"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsdocumentdb/iac/tf/provider.tf
+++ b/catalog/aws/awsdocumentdb/iac/tf/provider.tf
@@ -1,12 +1,19 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      # Floor, not a cap: DocumentDB Serverless
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor: DocumentDB Serverless
       # (serverless_v2_scaling_configuration, v6.10) and network_type
       # (v6.23) are v6-line additions -- the v6.23 floor keeps the module
       # on the modern major where the whole modeled surface is present.
-      version = ">= 6.23.0"
+      source  = "hashicorp/aws"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsdynamodb/iac/tf/provider.tf
+++ b/catalog/aws/awsdynamodb/iac/tf/provider.tf
@@ -1,12 +1,19 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      # Floor, not a pin: 6.37.0 carries the full surface this module
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor: 6.37.0 carries the full surface this module
       # renders -- global_table_witness (6.22), multi-attribute GSI
       # key_schema (6.29), and the 6.37 fix for GSI removal under the
       # key_schema syntax deleting every index on the table.
-      version = ">= 6.37.0"
+      source  = "hashicorp/aws"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsec2instance/iac/tf/provider.tf
+++ b/catalog/aws/awsec2instance/iac/tf/provider.tf
@@ -3,12 +3,18 @@ terraform {
 
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      # Floor, not a ceiling: cpu_options.nested_virtualization (6.33) is
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor: cpu_options.nested_virtualization (6.33) is
       # the newest argument this module uses; secondary_network_interface
-      # landed in 6.32 and primary_network_interface in 6.10. `init`
-      # resolves the latest release at or above the floor.
-      version = ">= 6.33.0"
+      # landed in 6.32 and primary_network_interface in 6.10.
+      source  = "hashicorp/aws"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsecrrepo/iac/tf/provider.tf
+++ b/catalog/aws/awsecrrepo/iac/tf/provider.tf
@@ -1,12 +1,19 @@
 terraform {
   required_providers {
     aws = {
-      # Floor 6.12.0: the IMMUTABLE_WITH_EXCLUSION / MUTABLE_WITH_EXCLUSION
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor 6.12.0: the IMMUTABLE_WITH_EXCLUSION / MUTABLE_WITH_EXCLUSION
       # mutability modes and image_tag_mutability_exclusion_filter landed
       # across 6.10.0–6.12.0 (aws_ecr_repository_policy and
       # aws_ecr_lifecycle_policy are far older).
       source  = "hashicorp/aws"
-      version = ">= 6.12.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsecscluster/iac/tf/provider.tf
+++ b/catalog/aws/awsecscluster/iac/tf/provider.tf
@@ -3,11 +3,17 @@ terraform {
 
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      # Floor, not a ceiling: the cluster's managed_storage_configuration
-      # and the capacity provider's managed_draining land on the v6 line;
-      # `init` resolves the latest release at or above the floor.
-      version = ">= 6.0.0"
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor: the cluster's managed_storage_configuration
+      # and the capacity provider's managed_draining land on the v6 line.
+      source  = "hashicorp/aws"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsecsservice/iac/tf/provider.tf
+++ b/catalog/aws/awsecsservice/iac/tf/provider.tf
@@ -1,13 +1,20 @@
 terraform {
   required_providers {
     aws = {
-      # Floor, not a cap: native blue/green deployments
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor: native blue/green deployments
       # (deployment_configuration, load_balancer.advanced_configuration),
       # alarm-gated rollbacks, Service Connect access logs, and managed EBS
       # task volumes all landed across the provider's v6 line -- this floor
       # is the first release carrying the full surface this module drives.
       source  = "hashicorp/aws"
-      version = ">= 6.50.0"
+      version = "~> 6.58"
     }
   }
 

--- a/catalog/aws/awsecstaskdefinition/iac/tf/provider.tf
+++ b/catalog/aws/awsecstaskdefinition/iac/tf/provider.tf
@@ -1,8 +1,14 @@
 terraform {
   required_providers {
     aws = {
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsefsaccesspoint/iac/tf/provider.tf
+++ b/catalog/aws/awsefsaccesspoint/iac/tf/provider.tf
@@ -1,11 +1,18 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      # Floor, not a ceiling: the access point surface is stable across the v6
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor: the access point surface is stable across the v6
       # line; the family floor matches the AwsElasticFileSystem module so the
       # two EFS kinds always resolve the same provider major.
-      version = ">= 6.12.0"
+      source  = "hashicorp/aws"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsegressonlyinternetgateway/iac/tf/provider.tf
+++ b/catalog/aws/awsegressonlyinternetgateway/iac/tf/provider.tf
@@ -1,8 +1,14 @@
 terraform {
   required_providers {
     aws = {
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awseksaccessentry/iac/tf/provider.tf
+++ b/catalog/aws/awseksaccessentry/iac/tf/provider.tf
@@ -1,8 +1,14 @@
 terraform {
   required_providers {
     aws = {
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awseksaddon/iac/tf/provider.tf
+++ b/catalog/aws/awseksaddon/iac/tf/provider.tf
@@ -1,8 +1,16 @@
 terraform {
   required_providers {
     aws = {
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor 6.42.0: the add-on's namespace_config argument landed there.
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsekscluster/iac/tf/provider.tf
+++ b/catalog/aws/awsekscluster/iac/tf/provider.tf
@@ -1,8 +1,16 @@
 terraform {
   required_providers {
     aws = {
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor 6.52.0: vpc_config.control_plane_egress_mode landed there.
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awseksfargateprofile/iac/tf/provider.tf
+++ b/catalog/aws/awseksfargateprofile/iac/tf/provider.tf
@@ -1,8 +1,14 @@
 terraform {
   required_providers {
     aws = {
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awseksnodegroup/iac/tf/provider.tf
+++ b/catalog/aws/awseksnodegroup/iac/tf/provider.tf
@@ -1,8 +1,14 @@
 terraform {
   required_providers {
     aws = {
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awselasticacheuser/iac/tf/provider.tf
+++ b/catalog/aws/awselasticacheuser/iac/tf/provider.tf
@@ -1,11 +1,18 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      # Floor, not a cap: the valkey engine value and the current
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor: the valkey engine value and the current
       # authentication_mode semantics are v6-era; an older floor would
       # silently reject part of the modeled surface.
-      version = ">= 6.0.0"
+      source  = "hashicorp/aws"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awselasticacheusergroup/iac/tf/provider.tf
+++ b/catalog/aws/awselasticacheusergroup/iac/tf/provider.tf
@@ -1,8 +1,14 @@
 terraform {
   required_providers {
     aws = {
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awselasticfilesystem/iac/tf/provider.tf
+++ b/catalog/aws/awselasticfilesystem/iac/tf/provider.tf
@@ -1,11 +1,18 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      # Floor, not a ceiling: mount-target ip_address_type/ipv6_address
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor: mount-target ip_address_type/ipv6_address
       # (dual-stack) landed in v6.12.0. Sibling AWS modules share the v6 line
       # so behavior never varies per kind.
-      version = ">= 6.12.0"
+      source  = "hashicorp/aws"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awselasticip/e2e/manifest.yaml
+++ b/catalog/aws/awselasticip/e2e/manifest.yaml
@@ -1,14 +1,6 @@
 apiVersion: aws.planton.dev/v1alpha1
 kind: AwsElasticIp
 metadata:
-  name: test-eip
-  org: test-org
-  env: dev
-  id: test-eip-dev
-  annotations:
-    planton.dev/provisioner: pulumi
-    pulumi.planton.dev/organization: test-org
-    pulumi.planton.dev/project: test-project
-    pulumi.planton.dev/stack.name: dev.AwsElasticIp.test-eip
+  name: static-egress-ip-demo
 spec:
-  region: us-east-1
+  region: us-west-2

--- a/catalog/aws/awselasticip/e2e/profile.yaml
+++ b/catalog/aws/awselasticip/e2e/profile.yaml
@@ -1,0 +1,16 @@
+apiVersion: qa.planton.dev/v1
+kind: ComponentE2EProfile
+metadata:
+  name: awselasticip
+spec:
+  # An Elastic IP under live E2E: the harness runs deploy -> DescribeAddresses
+  # verify -> destroy -> verify-destroyed on both provisioners. The scenario is
+  # allocation-only (the spec's BYOIP arms -- public_ipv4_pool, address -- need
+  # a pool the test account does not carry, and network_border_group needs an
+  # enabled Local Zone; all three are proven by the offline gate and spec
+  # tests). AWS bills public IPv4 addresses per-hour (~$0.005), so a lane
+  # costs under a cent; a leaked allocation keeps billing, which is exactly
+  # what verify-destroyed guards.
+  tier: 1
+  status: pending_proof
+  timeout_minutes: 10

--- a/catalog/aws/awselasticip/e2e/scenarios/minimal.yaml
+++ b/catalog/aws/awselasticip/e2e/scenarios/minimal.yaml
@@ -1,0 +1,28 @@
+# Minimal standalone AwsElasticIp scenario: a plain VPC-domain allocation in
+# one region -- exercising allocation, the allocation_id/public_ip/arn/
+# public_dns output contract, and released-allocation detection on destroy
+# (DescribeAddresses returns InvalidAllocationID.NotFound) on both engines.
+# The BYOIP arms (public_ipv4_pool + address) and network_border_group are
+# deliberately absent: they need account-level fixtures (a provisioned BYOIP
+# pool, an enabled Local Zone) no generic test account carries; their wiring
+# is proven by the offline gate and the spec's CEL tests. AwsElasticIp has no
+# registry prerequisites, so the harness applies this directly; the composed
+# allocation-reference path is exercised live by the AwsNatGateway scenario,
+# which deploys this kind's prerequisite manifest first. Full metadata is
+# supplied for tagging/orphan cleanup.
+apiVersion: aws.planton.dev/v1alpha1
+kind: AwsElasticIp
+metadata:
+  name: planton-oss-e2e-awselasticip-smoke
+  id: planton-oss-e2e-awselasticip-smoke
+  org: planton-oss
+  env: e2e
+  labels:
+    managed-by: planton-e2e
+    e2e-component: awselasticip
+  annotations:
+    planton.dev/e2e: "true"
+  tags:
+    - planton-e2e
+spec:
+  region: us-west-2

--- a/catalog/aws/awselasticip/iac/tf/provider.tf
+++ b/catalog/aws/awselasticip/iac/tf/provider.tf
@@ -1,8 +1,14 @@
 terraform {
   required_providers {
     aws = {
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
       source  = "hashicorp/aws"
-      version = "= 5.82.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awselasticip/v1alpha1/reference.md
+++ b/catalog/aws/awselasticip/v1alpha1/reference.md
@@ -34,17 +34,9 @@ Credentials, region, and deployment workflow live outside this spec in stack inp
 apiVersion: aws.planton.dev/v1alpha1
 kind: AwsElasticIp
 metadata:
-  name: test-eip
-  org: test-org
-  env: dev
-  id: test-eip-dev
-  annotations:
-    planton.dev/provisioner: pulumi
-    pulumi.planton.dev/organization: test-org
-    pulumi.planton.dev/project: test-project
-    pulumi.planton.dev/stack.name: dev.AwsElasticIp.test-eip
+  name: static-egress-ip-demo
 spec:
-  region: us-east-1
+  region: us-west-2
 ```
 
 ## Spec Fields

--- a/catalog/aws/awseventbridgebus/iac/tf/provider.tf
+++ b/catalog/aws/awseventbridgebus/iac/tf/provider.tf
@@ -1,10 +1,17 @@
 terraform {
   required_providers {
     aws = {
-      # v6 family floor — kms_key_identifier, dead_letter_config, and
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor (v6 family baseline): kms_key_identifier, dead_letter_config, and
       # log_config on aws_cloudwatch_event_bus require the 6.x provider line.
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awseventbridgerule/iac/tf/provider.tf
+++ b/catalog/aws/awseventbridgerule/iac/tf/provider.tf
@@ -1,11 +1,18 @@
 terraform {
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
-      # v6 family floor: the rule + target surface this module renders
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor (v6 family baseline): the rule + target surface this module renders
       # predates 6.0, so the floor is the family baseline rather than a
       # feature-driven minimum.
-      version = ">= 6.0.0"
+      source  = "hashicorp/aws"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsfsxdatarepositoryassociation/iac/tf/provider.tf
+++ b/catalog/aws/awsfsxdatarepositoryassociation/iac/tf/provider.tf
@@ -1,10 +1,17 @@
 terraform {
   required_providers {
     aws = {
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
       # The data repository association resource has carried this module's
       # full surface since the start of the v6 line.
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsfsxlustrefilesystem/iac/tf/provider.tf
+++ b/catalog/aws/awsfsxlustrefilesystem/iac/tf/provider.tf
@@ -1,13 +1,20 @@
 terraform {
   required_providers {
     aws = {
-      # Family floor: >= 6.8.0 carries the full Lustre surface used by this
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor 6.8.0 carries the full Lustre surface used by this
       # module — INTELLIGENT_TIERING with throughput_capacity and
       # data_read_cache_configuration (including the read-cache size
       # validation fixed in 6.8.0), efa_enabled, root_squash_configuration,
       # final_backup_tags, and the legacy S3 link arm.
       source  = "hashicorp/aws"
-      version = ">= 6.8.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsfsxontapfilesystem/iac/tf/provider.tf
+++ b/catalog/aws/awsfsxontapfilesystem/iac/tf/provider.tf
@@ -1,12 +1,19 @@
 terraform {
   required_providers {
     aws = {
-      # Family floor: the complete ONTAP file-system surface used by this
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor (family baseline): the complete ONTAP file-system surface used by this
       # module predates the v6 line (the last additions — MULTI_AZ_2 and the
       # second-generation throughput tiers — landed in 5.58.0), so the floor
       # is the v6 major itself, keeping the FSx family on one provider line.
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsfsxontapstoragevirtualmachine/iac/tf/provider.tf
+++ b/catalog/aws/awsfsxontapstoragevirtualmachine/iac/tf/provider.tf
@@ -1,11 +1,18 @@
 terraform {
   required_providers {
     aws = {
-      # Family floor: the complete SVM surface used by this module predates
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor (family baseline): the complete SVM surface used by this module predates
       # the v6 line, so the floor is the v6 major itself, keeping the FSx
       # family on one provider line.
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsfsxontapvolume/iac/tf/provider.tf
+++ b/catalog/aws/awsfsxontapvolume/iac/tf/provider.tf
@@ -1,12 +1,19 @@
 terraform {
   required_providers {
     aws = {
-      # Family floor: the complete volume surface used by this module
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor (family baseline): the complete volume surface used by this module
       # predates the v6 line (the last addition — final_backup_tags — landed
       # in 5.59.0), so the floor is the v6 major itself, keeping the FSx
       # family on one provider line.
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsfsxopenzfsfilesystem/iac/tf/provider.tf
+++ b/catalog/aws/awsfsxopenzfsfilesystem/iac/tf/provider.tf
@@ -1,12 +1,19 @@
 terraform {
   required_providers {
     aws = {
-      # Family floor: >= 6.22.1 carries the full OpenZFS surface used by this
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor 6.22.1 carries the full OpenZFS surface used by this
       # module — the INTELLIGENT_TIERING storage type with
       # read_cache_configuration (landed in 6.22.1), plus backup_id,
       # delete_options, and final_backup_tags.
       source  = "hashicorp/aws"
-      version = ">= 6.22.1"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsfsxwindowsfilesystem/iac/tf/provider.tf
+++ b/catalog/aws/awsfsxwindowsfilesystem/iac/tf/provider.tf
@@ -2,12 +2,19 @@ terraform {
   required_version = ">= 1.0"
   required_providers {
     aws = {
-      # Family floor: >= 6.29.0 carries the full Windows surface used by this
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor 6.29.0 carries the full Windows surface used by this
       # module — the self-managed AD domain_join_service_account_secret arm
       # with optional username/password (landed in 6.29.0), plus backup_id
       # and final_backup_tags.
       source  = "hashicorp/aws"
-      version = ">= 6.29.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsglobalaccelerator/iac/tf/provider.tf
+++ b/catalog/aws/awsglobalaccelerator/iac/tf/provider.tf
@@ -3,13 +3,20 @@ terraform {
 
   required_providers {
     aws = {
-      # Floor: >= 6.0.0. The newest arguments this module sends — the
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor 6.0.0. The newest arguments this module sends — the
       # endpoint configuration's attachment_arn (cross-account attachments)
       # and the accelerator's dual-stack surface — landed on the v5 line
       # (v5.47-v5.48), so the v6 major floor carries the full modeled
       # surface with current provider behavior.
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsgluecatalogdatabase/iac/tf/provider.tf
+++ b/catalog/aws/awsgluecatalogdatabase/iac/tf/provider.tf
@@ -3,11 +3,18 @@ terraform {
 
   required_providers {
     aws = {
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
       # The database surface (resource links, federation, Lake Formation
       # create-table grants) is stable across the v6 line; the floor keeps the
       # kind on the provider family the rest of the AWS catalog targets.
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awshttpapidomain/iac/tf/provider.tf
+++ b/catalog/aws/awshttpapidomain/iac/tf/provider.tf
@@ -2,11 +2,18 @@ terraform {
   required_version = ">= 1.0"
   required_providers {
     aws = {
-      # Floor 6.29.0: routing_mode landed on the domain resource in 6.29.0,
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor 6.29.0: routing_mode landed on the domain resource in 6.29.0,
       # changing its schema shape -- the family floor pins there so every
       # apigatewayv2 sibling resolves from the same provider build.
       source  = "hashicorp/aws"
-      version = ">= 6.29.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awshttpapigateway/iac/tf/provider.tf
+++ b/catalog/aws/awshttpapigateway/iac/tf/provider.tf
@@ -2,13 +2,20 @@ terraform {
   required_version = ">= 1.0"
   required_providers {
     aws = {
-      # Floor 6.29.0: the API/domain ip_address_type argument landed on the
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor 6.29.0: the API/domain ip_address_type argument landed on the
       # 5.97 line, but 6.29.0 is where the apigatewayv2 family last changed
       # shape (domain routing_mode / routing rules) -- pinning the family
       # floor there keeps every argument this module and its siblings use
       # resolvable from one provider build.
       source  = "hashicorp/aws"
-      version = ">= 6.29.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awshttpapivpclink/iac/tf/provider.tf
+++ b/catalog/aws/awshttpapivpclink/iac/tf/provider.tf
@@ -2,12 +2,19 @@ terraform {
   required_version = ">= 1.0"
   required_providers {
     aws = {
-      # Family floor: the apigatewayv2 family's newest shape change
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor (family baseline): the apigatewayv2 family's newest shape change
       # (routing_mode / routing rules) landed in 6.29.0; the VPC link
       # resource itself is far older, but the family pins one floor so every
       # sibling resolves from the same provider build.
       source  = "hashicorp/aws"
-      version = ">= 6.29.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsiaminstanceprofile/iac/tf/provider.tf
+++ b/catalog/aws/awsiaminstanceprofile/iac/tf/provider.tf
@@ -1,8 +1,14 @@
 terraform {
   required_providers {
     aws = {
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsiamoidcprovider/e2e/profile.yaml
+++ b/catalog/aws/awsiamoidcprovider/e2e/profile.yaml
@@ -10,8 +10,5 @@ spec:
   # allows one provider per unique URL per account) and never depends on an
   # external issuer being reachable. IAM is global and free.
   tier: 1
-  status: green
-  validated_provisioners:
-    - pulumi
-    - terraform
+  status: pending_proof
   timeout_minutes: 10

--- a/catalog/aws/awsiamoidcprovider/iac/tf/provider.tf
+++ b/catalog/aws/awsiamoidcprovider/iac/tf/provider.tf
@@ -1,8 +1,14 @@
 terraform {
   required_providers {
     aws = {
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsiampolicy/iac/tf/provider.tf
+++ b/catalog/aws/awsiampolicy/iac/tf/provider.tf
@@ -1,8 +1,14 @@
 terraform {
   required_providers {
     aws = {
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsiamrole/e2e/profile.yaml
+++ b/catalog/aws/awsiamrole/e2e/profile.yaml
@@ -9,8 +9,5 @@ spec:
   # AWS-managed policy by literal ARN and an inline policy, exercising the
   # attachment reconciliation on both engines. IAM is global and free.
   tier: 1
-  status: green
-  validated_provisioners:
-    - pulumi
-    - terraform
+  status: pending_proof
   timeout_minutes: 10

--- a/catalog/aws/awsiamrole/iac/tf/provider.tf
+++ b/catalog/aws/awsiamrole/iac/tf/provider.tf
@@ -1,8 +1,14 @@
 terraform {
   required_providers {
     aws = {
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsiamuser/iac/tf/provider.tf
+++ b/catalog/aws/awsiamuser/iac/tf/provider.tf
@@ -1,8 +1,14 @@
 terraform {
   required_providers {
     aws = {
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsinternetgateway/iac/tf/provider.tf
+++ b/catalog/aws/awsinternetgateway/iac/tf/provider.tf
@@ -1,8 +1,14 @@
 terraform {
   required_providers {
     aws = {
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awskinesisfirehose/iac/tf/provider.tf
+++ b/catalog/aws/awskinesisfirehose/iac/tf/provider.tf
@@ -1,12 +1,19 @@
 terraform {
   required_providers {
     aws = {
-      # Feature-driven floor: iceberg_configuration.append_only landed in
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor: iceberg_configuration.append_only landed in
       # 6.8.0 (the newest attribute this module renders; the Snowflake,
       # Iceberg, MSK-source, and secrets-manager blocks themselves all
       # predate the v6 line).
       source  = "hashicorp/aws"
-      version = ">= 6.8.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awskinesisstream/iac/tf/provider.tf
+++ b/catalog/aws/awskinesisstream/iac/tf/provider.tf
@@ -1,10 +1,17 @@
 terraform {
   required_providers {
     aws = {
-      # Floor 6.48.0: warm_throughput_mib_ps landed there (max_record_size_in_kib
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor 6.48.0: warm_throughput_mib_ps landed there (max_record_size_in_kib
       # in 6.20.0, aws_kinesis_resource_policy well before the v6 line).
       source  = "hashicorp/aws"
-      version = ">= 6.48.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awskinesisstreamconsumer/iac/tf/provider.tf
+++ b/catalog/aws/awskinesisstreamconsumer/iac/tf/provider.tf
@@ -1,10 +1,17 @@
 terraform {
   required_providers {
     aws = {
-      # Floor 6.2.0: consumer tags landed there (aws_kinesis_resource_policy
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor 6.2.0: consumer tags landed there (aws_kinesis_resource_policy
       # predates the v6 line).
       source  = "hashicorp/aws"
-      version = ">= 6.2.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awskmskey/iac/tf/provider.tf
+++ b/catalog/aws/awskmskey/iac/tf/provider.tf
@@ -1,10 +1,17 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      # Floor, not a pin: aws_kms_key rotation_period_in_days and multi_region
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor: aws_kms_key rotation_period_in_days and multi_region
       # are stable across the v6 line.
-      version = ">= 6.0.0"
+      source  = "hashicorp/aws"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awslambda/iac/tf/provider.tf
+++ b/catalog/aws/awslambda/iac/tf/provider.tf
@@ -1,12 +1,19 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      # Floor, not a pin: 6.0 carries the full surface this module
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor: 6.0 carries the full surface this module
       # renders (logging_config, snap_start, ipv6_allowed_for_dual_stack,
       # source_kms_key_arn, the recursion and runtime-management
       # resources all predate the v6 line).
-      version = ">= 6.0.0"
+      source  = "hashicorp/aws"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awslambdaeventsourcemapping/iac/tf/provider.tf
+++ b/catalog/aws/awslambdaeventsourcemapping/iac/tf/provider.tf
@@ -1,11 +1,18 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      # Floor, not a pin: the newest surface this module renders is the Kafka
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor: the newest surface this module renders is the Kafka
       # schema_registry_config block, added to aws_lambda_event_source_mapping
       # in provider 6.16.0.
-      version = ">= 6.16.0"
+      source  = "hashicorp/aws"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awslaunchtemplate/iac/tf/provider.tf
+++ b/catalog/aws/awslaunchtemplate/iac/tf/provider.tf
@@ -1,8 +1,14 @@
 terraform {
   required_providers {
     aws = {
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awslblistener/iac/tf/provider.tf
+++ b/catalog/aws/awslblistener/iac/tf/provider.tf
@@ -1,8 +1,14 @@
 terraform {
   required_providers {
     aws = {
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awslblistenerrule/iac/tf/provider.tf
+++ b/catalog/aws/awslblistenerrule/iac/tf/provider.tf
@@ -1,8 +1,14 @@
 terraform {
   required_providers {
     aws = {
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awslbtargetgroup/iac/tf/provider.tf
+++ b/catalog/aws/awslbtargetgroup/iac/tf/provider.tf
@@ -1,8 +1,14 @@
 terraform {
   required_providers {
     aws = {
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsmemcachedelasticache/iac/tf/provider.tf
+++ b/catalog/aws/awsmemcachedelasticache/iac/tf/provider.tf
@@ -1,8 +1,14 @@
 terraform {
   required_providers {
     aws = {
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsmemorydbacl/iac/tf/provider.tf
+++ b/catalog/aws/awsmemorydbacl/iac/tf/provider.tf
@@ -1,12 +1,19 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      # Floor, not a cap: the MemoryDB family floor is set by the cluster's
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor: the MemoryDB family floor is set by the cluster's
       # ip_discovery/network_type arguments (v6.34.0); the ACL resource
       # itself is stable across the v6 line, and one family floor keeps the
       # engines' resolved provider versions aligned.
-      version = ">= 6.34.0"
+      source  = "hashicorp/aws"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsmemorydbcluster/iac/tf/provider.tf
+++ b/catalog/aws/awsmemorydbcluster/iac/tf/provider.tf
@@ -3,11 +3,18 @@ terraform {
 
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      # Floor, not a cap: ip_discovery and network_type land in v6.34.0 --
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor: ip_discovery and network_type land in v6.34.0 --
       # an older floor would silently reject the dual-stack surface. (The
       # valkey engine and multi_region_cluster_name predate it.)
-      version = ">= 6.34.0"
+      source  = "hashicorp/aws"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsmemorydbuser/iac/tf/provider.tf
+++ b/catalog/aws/awsmemorydbuser/iac/tf/provider.tf
@@ -1,12 +1,19 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      # Floor, not a cap: the MemoryDB family floor is set by the cluster's
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor: the MemoryDB family floor is set by the cluster's
       # ip_discovery/network_type arguments (v6.34.0); the user resource
       # itself is stable across the v6 line, and one family floor keeps the
       # engines' resolved provider versions aligned.
-      version = ">= 6.34.0"
+      source  = "hashicorp/aws"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsmskcluster/iac/tf/provider.tf
+++ b/catalog/aws/awsmskcluster/iac/tf/provider.tf
@@ -1,12 +1,19 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      # Floor, not a cap: connectivity_info.network_type landed in 6.40.0 and
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor: connectivity_info.network_type landed in 6.40.0 and
       # 6.41.0 fixed a vpc_connectivity update regression introduced there;
       # the rebalancing block (Express brokers) is older (6.22.1). Everything
       # else this module uses predates the v6 line.
-      version = ">= 6.41.0"
+      source  = "hashicorp/aws"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsmskserverlesscluster/iac/tf/provider.tf
+++ b/catalog/aws/awsmskserverlesscluster/iac/tf/provider.tf
@@ -1,10 +1,17 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      # Floor, not a cap: aws_msk_serverless_cluster is stable across the v6
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor: aws_msk_serverless_cluster is stable across the v6
       # line; nothing this module uses is newer.
-      version = ">= 6.0.0"
+      source  = "hashicorp/aws"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsmwaaenvironment/e2e/manifest.yaml
+++ b/catalog/aws/awsmwaaenvironment/e2e/manifest.yaml
@@ -6,15 +6,15 @@ spec:
   region: us-west-2
   airflowVersion: "2.10.1"
   sourceBucketArn:
-    value: "<s3-bucket-arn>"
+    value: "arn:aws:s3:::airflow-dags-bucket"
   dagS3Path: "dags/"
   executionRoleArn:
-    value: "<execution-role-arn>"
+    value: "arn:aws:iam::123456789012:role/airflow-execution-role"
   subnetIds:
-    - value: "<private-subnet-id-az1>"
-    - value: "<private-subnet-id-az2>"
+    - value: "subnet-0a1b2c3d4e5f60001"
+    - value: "subnet-0a1b2c3d4e5f60002"
   securityGroupIds:
-    - value: "<mwaa-security-group-id>"
+    - value: "sg-0a1b2c3d4e5f60003"
   environmentClass: mw1.small
   minWorkers: 1
   maxWorkers: 5

--- a/catalog/aws/awsmwaaenvironment/iac/tf/provider.tf
+++ b/catalog/aws/awsmwaaenvironment/iac/tf/provider.tf
@@ -1,10 +1,17 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      # Floor, not a cap: worker_replacement_strategy landed in 6.11.0;
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor: worker_replacement_strategy landed in 6.11.0;
       # everything else this module uses predates the v6 line.
-      version = ">= 6.11.0"
+      source  = "hashicorp/aws"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsmwaaenvironment/v1alpha1/reference.md
+++ b/catalog/aws/awsmwaaenvironment/v1alpha1/reference.md
@@ -34,15 +34,15 @@ spec:
   region: us-west-2
   airflowVersion: "2.10.1"
   sourceBucketArn:
-    value: "<s3-bucket-arn>"
+    value: "arn:aws:s3:::airflow-dags-bucket"
   dagS3Path: "dags/"
   executionRoleArn:
-    value: "<execution-role-arn>"
+    value: "arn:aws:iam::123456789012:role/airflow-execution-role"
   subnetIds:
-    - value: "<private-subnet-id-az1>"
-    - value: "<private-subnet-id-az2>"
+    - value: "subnet-0a1b2c3d4e5f60001"
+    - value: "subnet-0a1b2c3d4e5f60002"
   securityGroupIds:
-    - value: "<mwaa-security-group-id>"
+    - value: "sg-0a1b2c3d4e5f60003"
   environmentClass: mw1.small
   minWorkers: 1
   maxWorkers: 5

--- a/catalog/aws/awsnatgateway/iac/tf/provider.tf
+++ b/catalog/aws/awsnatgateway/iac/tf/provider.tf
@@ -1,8 +1,14 @@
 terraform {
   required_providers {
     aws = {
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsneptunecluster/iac/tf/provider.tf
+++ b/catalog/aws/awsneptunecluster/iac/tf/provider.tf
@@ -1,11 +1,18 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      # Floor, not a cap: the v6 floor keeps the module on the modern
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor: the v6 floor keeps the module on the modern
       # major where the whole modeled Neptune surface (serverless
       # scaling, iopt1 storage, global cluster membership) is present.
-      version = ">= 6.0.0"
+      source  = "hashicorp/aws"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsnlb/iac/tf/provider.tf
+++ b/catalog/aws/awsnlb/iac/tf/provider.tf
@@ -3,8 +3,14 @@ terraform {
 
   required_providers {
     aws = {
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsopensearchdomain/iac/tf/provider.tf
+++ b/catalog/aws/awsopensearchdomain/iac/tf/provider.tf
@@ -1,11 +1,18 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      # Floor, not a cap: aiml_options landed in 6.15.0, identity_center_options
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor: aiml_options landed in 6.15.0, identity_center_options
       # in 6.20.0, and the aiml serverless_vector_acceleration block this module
       # emits arrived in 6.31.0 -- the newest argument in use.
-      version = ">= 6.31.0"
+      source  = "hashicorp/aws"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsplantonrunner/iac/tf/provider.tf
+++ b/catalog/aws/awsplantonrunner/iac/tf/provider.tf
@@ -1,11 +1,18 @@
 terraform {
   required_providers {
     aws = {
-      # Floor, not a cap: everything this module drives (ECS Fargate,
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor: everything this module drives (ECS Fargate,
       # Secrets Manager, IAM, CloudWatch Logs) is stable across the
       # provider's v6 line.
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = "~> 6.58"
     }
   }
 

--- a/catalog/aws/awsrdscluster/iac/tf/provider.tf
+++ b/catalog/aws/awsrdscluster/iac/tf/provider.tf
@@ -1,13 +1,20 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      # Floor, not a cap: Serverless v2 automatic pause
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor: Serverless v2 automatic pause
       # (serverlessv2_scaling_configuration.seconds_until_auto_pause) and
       # database_insights_mode are late-v5 additions -- the v6 floor keeps
       # the module on the modern major where the whole modeled surface
       # (including the iam-db-auth-error log type) is present.
-      version = ">= 6.0.0"
+      source  = "hashicorp/aws"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsrdsinstance/iac/tf/provider.tf
+++ b/catalog/aws/awsrdsinstance/iac/tf/provider.tf
@@ -1,12 +1,19 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      # Floor, not a cap: dedicated_log_volume, database_insights_mode,
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor: dedicated_log_volume, database_insights_mode,
       # and the self-managed Active Directory arguments are late-v5
       # additions -- the v6 floor keeps the module on the modern major
       # where the whole modeled surface is present.
-      version = ">= 6.0.0"
+      source  = "hashicorp/aws"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsrediselasticache/iac/tf/provider.tf
+++ b/catalog/aws/awsrediselasticache/iac/tf/provider.tf
@@ -1,8 +1,14 @@
 terraform {
   required_providers {
     aws = {
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsredshiftcluster/iac/tf/provider.tf
+++ b/catalog/aws/awsredshiftcluster/iac/tf/provider.tf
@@ -1,13 +1,20 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      # Floor, not a cap: the v6 line is where aws_redshift_cluster's
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor: the v6 line is where aws_redshift_cluster's
       # encrypted defaults to true, publicly_accessible defaults to
       # false, and the inline logging/snapshot_copy blocks gave way to
       # the standalone aws_redshift_logging and aws_redshift_snapshot_copy
       # resources this module uses.
-      version = ">= 6.0.0"
+      source  = "hashicorp/aws"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsredshiftserverlessnamespace/iac/tf/provider.tf
+++ b/catalog/aws/awsredshiftserverlessnamespace/iac/tf/provider.tf
@@ -1,12 +1,19 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      # Floor, not a cap: the v6 line carries the full
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor: the v6 line carries the full
       # aws_redshiftserverless_namespace surface this module uses,
       # including the Secrets-Manager-managed admin password
       # (manage_admin_password + admin_password_secret_kms_key_id).
-      version = ">= 6.0.0"
+      source  = "hashicorp/aws"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsredshiftserverlessworkgroup/iac/tf/provider.tf
+++ b/catalog/aws/awsredshiftserverlessworkgroup/iac/tf/provider.tf
@@ -1,11 +1,18 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      # Floor, not a cap: the v6 line carries the full
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor: the v6 line carries the full
       # aws_redshiftserverless_workgroup surface this module uses,
       # including price_performance_target and track_name.
-      version = ">= 6.0.0"
+      source  = "hashicorp/aws"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsroute53dnsrecord/iac/tf/provider.tf
+++ b/catalog/aws/awsroute53dnsrecord/iac/tf/provider.tf
@@ -1,10 +1,17 @@
 terraform {
   required_providers {
     aws = {
-      # v6 family floor: every modeled argument (geoproximity/CIDR/multivalue
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor (v6 family baseline): every modeled argument (geoproximity/CIDR/multivalue
       # routing, allow_overwrite, alias) predates the v6 line.
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsroute53healthcheck/iac/tf/provider.tf
+++ b/catalog/aws/awsroute53healthcheck/iac/tf/provider.tf
@@ -1,10 +1,17 @@
 terraform {
   required_providers {
     aws = {
-      # v6 family floor: the whole health-check surface (all eight check
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor (v6 family baseline): the whole health-check surface (all eight check
       # types, checker regions, latency graphs) predates the v6 line.
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsroute53zone/iac/tf/provider.tf
+++ b/catalog/aws/awsroute53zone/iac/tf/provider.tf
@@ -1,10 +1,17 @@
 terraform {
   required_providers {
     aws = {
-      # Floor 6.25.0: enable_accelerated_recovery landed there (the zone's
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor 6.25.0: enable_accelerated_recovery landed there (the zone's
       # vpc block, DNSSEC resources, and query logging are far older).
       source  = "hashicorp/aws"
-      version = ">= 6.25.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awss3bucket/iac/tf/provider.tf
+++ b/catalog/aws/awss3bucket/iac/tf/provider.tf
@@ -1,12 +1,19 @@
 terraform {
   required_providers {
     aws = {
-      # v6 family floor: every attribute this module renders (incl.
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor (v6 family baseline): every attribute this module renders (incl.
       # transition_default_minimum_object_size, partitioned log prefixes,
       # and DSSE-KMS) predates 6.0, so the floor is the family baseline
       # rather than a feature-driven minimum.
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awss3objectset/iac/tf/provider.tf
+++ b/catalog/aws/awss3objectset/iac/tf/provider.tf
@@ -1,14 +1,21 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      # Floor 6.1.0: the earliest release whose vendored S3 SDK accepts every
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor 6.1.0: the earliest release whose vendored S3 SDK accepts every
       # enum value the spec allows — the FSx-flavored storage classes
       # (FSX_OPENZFS / FSX_ONTAP) and the aws:fsx encryption value land in
       # 6.1.0's SDK; the provider validates these client-side, so an older
       # provider would reject manifests using them. Everything else on
       # aws_s3_object predates the v6 line.
-      version = ">= 6.1.0"
+      source  = "hashicorp/aws"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awssagemakerdomain/iac/tf/provider.tf
+++ b/catalog/aws/awssagemakerdomain/iac/tf/provider.tf
@@ -1,11 +1,18 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      # Floor 6.33.0: the newest argument this module sends
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor 6.33.0: the newest argument this module sends
       # (domain_settings.trusted_identity_propagation_settings) landed in
       # provider 6.33.0; every other block in the module predates it.
-      version = ">= 6.33.0"
+      source  = "hashicorp/aws"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awssecuritygroup/iac/tf/provider.tf
+++ b/catalog/aws/awssecuritygroup/iac/tf/provider.tf
@@ -1,10 +1,17 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      # Floor, not a cap: everything this module uses (inline rules, prefix
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor: everything this module uses (inline rules, prefix
       # lists, revoke_rules_on_delete) is stable across the v6 line.
-      version = ">= 6.0.0"
+      source  = "hashicorp/aws"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsserverlesselasticache/iac/tf/provider.tf
+++ b/catalog/aws/awsserverlesselasticache/iac/tf/provider.tf
@@ -1,8 +1,14 @@
 terraform {
   required_providers {
     aws = {
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awssesconfigurationset/iac/tf/provider.tf
+++ b/catalog/aws/awssesconfigurationset/iac/tf/provider.tf
@@ -1,12 +1,19 @@
 terraform {
   required_providers {
     aws = {
-      # v6 family floor: the full SESv2 configuration-set surface modeled
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor (v6 family baseline): the full SESv2 configuration-set surface modeled
       # here (including tracking https_policy and delivery
       # max_delivery_seconds, both provider v5.81.0+) is stable before the
       # v6 line; the floor keeps the SES family on one provider generation.
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awssesemailidentity/iac/tf/provider.tf
+++ b/catalog/aws/awssesemailidentity/iac/tf/provider.tf
@@ -1,12 +1,19 @@
 terraform {
   required_providers {
     aws = {
-      # v6 family floor: the full SESv2 email-identity surface modeled here
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor (v6 family baseline): the full SESv2 email-identity surface modeled here
       # (identity + mail-from + feedback + policy sub-resources) is stable
       # before the v6 line; the floor keeps the SES family on one provider
       # generation.
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awssnssubscription/e2e/manifest.yaml
+++ b/catalog/aws/awssnssubscription/e2e/manifest.yaml
@@ -5,8 +5,8 @@ metadata:
 spec:
   region: us-west-2
   topicArn:
-    value: "<sns-topic-arn>"
+    value: "arn:aws:sns:us-west-2:123456789012:order-events"
   protocol: sqs
   endpoint:
-    value: "<sqs-queue-arn>"
+    value: "arn:aws:sqs:us-west-2:123456789012:order-processor"
   rawMessageDelivery: true

--- a/catalog/aws/awssnssubscription/iac/tf/provider.tf
+++ b/catalog/aws/awssnssubscription/iac/tf/provider.tf
@@ -1,11 +1,18 @@
 terraform {
   required_providers {
     aws = {
-      # v6 family floor: everything this module renders (incl. replay_policy)
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor (v6 family baseline): everything this module renders (incl. replay_policy)
       # predates 6.0, so the floor is the family baseline rather than a
       # feature-driven minimum.
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awssnssubscription/v1alpha1/reference.md
+++ b/catalog/aws/awssnssubscription/v1alpha1/reference.md
@@ -38,10 +38,10 @@ metadata:
 spec:
   region: us-west-2
   topicArn:
-    value: "<sns-topic-arn>"
+    value: "arn:aws:sns:us-west-2:123456789012:order-events"
   protocol: sqs
   endpoint:
-    value: "<sqs-queue-arn>"
+    value: "arn:aws:sqs:us-west-2:123456789012:order-processor"
   rawMessageDelivery: true
 ```
 

--- a/catalog/aws/awssnstopic/iac/tf/provider.tf
+++ b/catalog/aws/awssnstopic/iac/tf/provider.tf
@@ -1,11 +1,18 @@
 terraform {
   required_providers {
     aws = {
-      # v6 family floor: everything this module renders (incl. archive_policy
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor (v6 family baseline): everything this module renders (incl. archive_policy
       # and the data protection policy satellite) predates 6.0, so the floor
       # is the family baseline rather than a feature-driven minimum.
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awssqsqueue/iac/tf/provider.tf
+++ b/catalog/aws/awssqsqueue/iac/tf/provider.tf
@@ -1,11 +1,18 @@
 terraform {
   required_providers {
     aws = {
-      # v6 family floor: every attribute this module renders (incl.
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor (v6 family baseline): every attribute this module renders (incl.
       # redrive_allow_policy) long predates 6.0, so the floor is the family
       # baseline rather than a feature-driven minimum.
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsstepfunction/iac/tf/provider.tf
+++ b/catalog/aws/awsstepfunction/iac/tf/provider.tf
@@ -2,12 +2,19 @@ terraform {
   required_version = ">= 1.0"
   required_providers {
     aws = {
-      # Family floor on the v6 line. Everything this module uses (publish +
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor: the v6 line. Everything this module uses (publish +
       # versioning outputs, encryption_configuration, logging plan-time
       # validation) predates 6.0, so the floor is the family convention, not
       # a feature gate.
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awssubnet/iac/tf/provider.tf
+++ b/catalog/aws/awssubnet/iac/tf/provider.tf
@@ -1,8 +1,14 @@
 terraform {
   required_providers {
     aws = {
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awstransitgateway/iac/tf/provider.tf
+++ b/catalog/aws/awstransitgateway/iac/tf/provider.tf
@@ -2,13 +2,20 @@ terraform {
   required_version = ">= 1.0"
   required_providers {
     aws = {
-      # Family floor: >= 6.26.0. The gateway's encryption_support argument
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor 6.26.0. The gateway's encryption_support argument
       # landed in 6.25.0 with a crash regression that 6.26.0 fixed, so the
       # floor deliberately clears the broken release. The whole Transit
       # Gateway family (gateway, VPC attachment, route table) shares this
       # floor so composed deployments resolve one provider build.
       source  = "hashicorp/aws"
-      version = ">= 6.26.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awstransitgatewayroutetable/iac/tf/provider.tf
+++ b/catalog/aws/awstransitgatewayroutetable/iac/tf/provider.tf
@@ -2,13 +2,20 @@ terraform {
   required_version = ">= 1.0"
   required_providers {
     aws = {
-      # Family floor: >= 6.26.0, shared across the Transit Gateway family
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor 6.26.0, shared across the Transit Gateway family
       # (gateway, VPC attachment, route table) so composed deployments
       # resolve one provider build. The floor is set by the gateway's
       # encryption_support argument (landed 6.25.0 with a crash regression
       # fixed in 6.26.0); the route table resources themselves predate v6.
       source  = "hashicorp/aws"
-      version = ">= 6.26.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awstransitgatewayvpcattachment/iac/tf/provider.tf
+++ b/catalog/aws/awstransitgatewayvpcattachment/iac/tf/provider.tf
@@ -2,13 +2,20 @@ terraform {
   required_version = ">= 1.0"
   required_providers {
     aws = {
-      # Family floor: >= 6.26.0, shared across the Transit Gateway family
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor 6.26.0, shared across the Transit Gateway family
       # (gateway, VPC attachment, route table) so composed deployments
       # resolve one provider build. The floor is set by the gateway's
       # encryption_support argument (landed 6.25.0 with a crash regression
       # fixed in 6.26.0); the attachment resource itself predates v6.
       source  = "hashicorp/aws"
-      version = ">= 6.26.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsvpc/iac/tf/provider.tf
+++ b/catalog/aws/awsvpc/iac/tf/provider.tf
@@ -1,8 +1,14 @@
 terraform {
   required_providers {
     aws = {
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awsvpcendpoint/iac/tf/provider.tf
+++ b/catalog/aws/awsvpcendpoint/iac/tf/provider.tf
@@ -1,12 +1,19 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      # Floor, not a cap: dns_options.private_dns_preference and
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor: dns_options.private_dns_preference and
       # private_dns_specified_domains landed in provider 6.28.0, and the
       # Resource / ServiceNetwork endpoint types are v6-era -- an older
       # floor would silently reject parts of the modeled surface.
-      version = ">= 6.28.0"
+      source  = "hashicorp/aws"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awswafipset/iac/tf/provider.tf
+++ b/catalog/aws/awswafipset/iac/tf/provider.tf
@@ -1,11 +1,18 @@
 terraform {
   required_providers {
     aws = {
-      # v6 family floor: the IP-set surface (scope, address version, CIDR
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor (v6 family baseline): the IP-set surface (scope, address version, CIDR
       # list) is stable well before the v6 line; the floor keeps the WAF
       # family on one provider generation.
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awswafregexpatternset/iac/tf/provider.tf
+++ b/catalog/aws/awswafregexpatternset/iac/tf/provider.tf
@@ -1,11 +1,18 @@
 terraform {
   required_providers {
     aws = {
-      # v6 family floor: the regex-pattern-set surface (scope, expressions)
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor (v6 family baseline): the regex-pattern-set surface (scope, expressions)
       # is stable well before the v6 line; the floor keeps the WAF family on
       # one provider generation.
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/catalog/aws/awswafwebacl/iac/tf/provider.tf
+++ b/catalog/aws/awswafwebacl/iac/tf/provider.tf
@@ -1,11 +1,18 @@
 terraform {
   required_providers {
     aws = {
-      # v6 floor: the asn_match statement landed in 6.0.0 (rule_json itself
+      # One pessimistic pin, catalog-wide: every AWS module tracks the same
+      # provider line, floored at the newest minor already released when the
+      # monthly pin sweep last advanced it. The `~>` cap makes the next major
+      # a deliberate catalog-wide decision, and floor-at-latest-released-minor
+      # means the constraint never understates what any module's newest
+      # argument needs. Only the sweep moves this line — never a single kind.
+      #
+      # Feature floor (v6 baseline): the asn_match statement landed in 6.0.0 (rule_json itself
       # in 5.61, data_protection_config in 5.100) -- the full modeled
       # surface needs the v6 line.
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = "~> 6.58"
     }
   }
 }

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -533,6 +533,21 @@ default-rule-set IDs are bare numerics (`942100`) -- an inferred bare
 `300700` was rejected by ARM on both engines with "managed rule IDs are
 not supported".
 
+### Angle-bracket placeholders in canonical manifests fail the offline plan gate
+
+A kind's `e2e/manifest.yaml` is the canonical validated example — refgen's
+Example source AND an offline-plan fixture — so every reference-shaped
+value in it must be syntactically REAL, never a `<placeholder>`. Provider
+schemas validate resource-identifier syntax at plan time (the AWS provider
+runs `ValidARN` on every ARN-typed argument), so `value: "<sns-topic-arn>"`
+passes proto validation (a free string) and fails the offline `tofu plan`
+with "invalid ARN: arn: invalid prefix". Use realistic well-formed values
+(`arn:aws:sns:us-west-2:123456789012:order-events`,
+`subnet-0a1b2c3d4e5f60001`) — they document the expected shape for users
+and agents, and they keep the manifest a working plan fixture. The same
+rule already governs presets; the trap here is that a manifest predating
+the offline gate can hide placeholders for years.
+
 ### Placeholder domains in receiver/endpoint URLs are server-validated
 
 When a fixture (or preset, or hack manifest) carries a URL the SERVICE

--- a/e2e/aws/aws_test.go
+++ b/e2e/aws/aws_test.go
@@ -87,6 +87,15 @@ func TestAwsVpc_Terraform(t *testing.T) { runAllScenariosForComponent(t, "awsvpc
 func TestAwsSubnet_Pulumi(t *testing.T)    { runAllScenariosForComponent(t, "awssubnet", "pulumi") }
 func TestAwsSubnet_Terraform(t *testing.T) { runAllScenariosForComponent(t, "awssubnet", "terraform") }
 
+// --- AWS Elastic IP (standalone allocation; also serves as the NAT Gateway prerequisite) ---
+
+func TestAwsElasticIp_Pulumi(t *testing.T) {
+	runAllScenariosForComponent(t, "awselasticip", "pulumi")
+}
+func TestAwsElasticIp_Terraform(t *testing.T) {
+	runAllScenariosForComponent(t, "awselasticip", "terraform")
+}
+
 // --- AWS NAT Gateway (deep composed topology: AwsVpc -> AwsSubnet -> AwsElasticIp) ---
 
 func TestAwsNatGateway_Pulumi(t *testing.T) {

--- a/hack/guards/ensure_tf_provider_pins.sh
+++ b/hack/guards/ensure_tf_provider_pins.sh
@@ -26,7 +26,22 @@ cd "$repo_root_dir"
 
 catalog_root="catalog"
 
+# Canonical catalog-wide pins.
+#
+# A cloud provider's modules unify on ONE pessimistic constraint, advanced
+# only by the monthly pin sweep. Once unified, per-module drift is a defect:
+# a lower floor can lie about what a module's arguments need, an unbounded
+# floor lets upgrades flow in uncontrolled, and an off-style pin fragments
+# the catalog's provider resolution. Each row is
+# "<catalog dir>|<provider local name>|<exact required constraint>"; a cloud
+# appends its row in the change that lands its unification sweep, and the
+# monthly sweep updates the constraint here and in every module together.
+canonical_pins=(
+  "aws|aws|~> 6.58"
+)
+
 violations=()
+pin_violations=()
 
 # Extracts the provider local-name keys declared inside required_providers blocks,
 # tracking brace depth so only top-level entries ("<name> = {") at the providers level
@@ -42,6 +57,26 @@ extract_declared() {
       if (depth<=0) inrp=0
     }
   ' "$@" | sort -u
+}
+
+# Extracts the version constraint declared for one provider local name inside
+# required_providers blocks (same depth-tracking as extract_declared).
+extract_version() {
+  local want="$1"
+  shift
+  awk -v want="$want" '
+    inrp==0 && /required_providers[ \t]*\{/ { inrp=1; depth=1; next }
+    inrp==1 {
+      if (depth==1 && match($0, /^[ \t]*[A-Za-z0-9_-]+[ \t]*=[ \t]*\{/)) {
+        k=$0; sub(/^[ \t]*/,"",k); sub(/[ \t]*=.*/,"",k); inentry=(k==want)
+      }
+      if (inentry && match($0, /^[ \t]*version[ \t]*=[ \t]*"/)) {
+        v=$0; sub(/^[ \t]*version[ \t]*=[ \t]*"/,"",v); sub(/".*/,"",v); print v
+      }
+      o=$0; ob=gsub(/\{/,"x",o); c=$0; cb=gsub(/\}/,"x",c); depth += ob - cb
+      if (depth<=0) { inrp=0; inentry=0 }
+    }
+  ' "$@"
 }
 
 # Collects referenced provider local names from resource/data block headers.
@@ -74,7 +109,26 @@ while IFS= read -r tfdir; do
   if [[ ${#missing[@]} -gt 0 ]]; then
     violations+=("${tfdir} -> unpinned: ${missing[*]}")
   fi
+
+  # Canonical-pin conformance (see the canonical_pins table above).
+  cloud_dir="${tfdir#catalog/}"
+  cloud_dir="${cloud_dir%%/*}"
+  for rule in "${canonical_pins[@]}"; do
+    rule_cloud="${rule%%|*}"
+    rest="${rule#*|}"
+    rule_name="${rest%%|*}"
+    rule_pin="${rest#*|}"
+    [[ "$cloud_dir" == "$rule_cloud" ]] || continue
+    if printf '%s\n' "$declared" | grep -qx "$rule_name"; then
+      actual="$(extract_version "$rule_name" "${tffiles[@]}" | head -n 1)"
+      if [[ "$actual" != "$rule_pin" ]]; then
+        pin_violations+=("${tfdir} -> ${rule_name} = \"${actual:-<no version>}\" (canonical: \"${rule_pin}\")")
+      fi
+    fi
+  done
 done < <(find "$catalog_root" -type d -path "*/iac/tf" 2>/dev/null | grep -E '^catalog/[^/]+/[^/]+/iac/tf$' | sort)
+
+failed=0
 
 if [[ ${#violations[@]} -gt 0 ]]; then
   echo "ERROR: ${#violations[@]} Terraform module(s) reference a provider without pinning it in required_providers." >&2
@@ -82,8 +136,21 @@ if [[ ${#violations[@]} -gt 0 ]]; then
   echo "Add the provider to a 'terraform { required_providers { ... } }' block (pin the major, e.g. helm \"~> 3.0\"):" >&2
   printf '  - %s\n' "${violations[@]}" >&2
   echo >&2
+  failed=1
+fi
+
+if [[ ${#pin_violations[@]} -gt 0 ]]; then
+  echo "ERROR: ${#pin_violations[@]} Terraform module(s) deviate from their cloud's canonical provider pin." >&2
+  echo "Unified clouds carry ONE constraint in every module; only the monthly pin sweep changes it" >&2
+  echo "(update the canonical_pins table in this guard and every module together):" >&2
+  printf '  - %s\n' "${pin_violations[@]}" >&2
+  echo >&2
+  failed=1
+fi
+
+if [[ $failed -ne 0 ]]; then
   echo "Terraform provider-pin guard FAILED." >&2
   exit 1
 fi
 
-echo "Terraform provider-pin guard passed: every iac/tf module pins all referenced providers."
+echo "Terraform provider-pin guard passed: every iac/tf module pins all referenced providers, and unified clouds carry their canonical pin."


### PR DESCRIPTION
## Summary
- Unifies every `catalog/aws/*/iac/tf/provider.tf` on the single pessimistic pin `~> 6.58` (latest released minor), replacing three coexisting regimes — unbounded floors, stale/lying 5.x floors, `= 5.82.0` freezes, and `~> 5.0` caps — with one policy-commented constraint; per-module feature-floor knowledge is preserved in each file.
- Extends the tf-provider-pins CI guard with a `canonical_pins` table so any module deviating from its cloud's canonical pin fails mechanically (negative-tested); other clouds enroll by adding a row.
- Flips the four kinds whose RESOLVED provider major actually changed (awsiamrole, awsiamoidcprovider, awselasticip, awscognitoidentityprovider) to `pending_proof` for live re-verification; awselasticip gains its missing e2e surface (profile, scenario, test entrypoints).
- Fixes two canonical manifests carrying `<placeholder>` ARNs that plan-time ARN validation rejects, and records the lesson in the e2e README.

## Verification
- Pin guard green (positive + negative test); offline `tofu init`+`plan` green for 111/112 kinds at the new pin (awsplantonrunner needs live fixtures — provider-version-independent); `go test ./pkg/anatomy/ ./pkg/e2e/profile/` green; `go vet -tags=e2e ./e2e/aws/` green.
- Live dual-engine re-proof of the four major-jump kinds runs via the e2e lanes (profiles honestly `pending_proof` until then).