### PR TITLE
E2E failure-mode lanes: the runner appliance proven on all four substrates

### DIFF
--- a/catalog/aws/aa_e2e/harness.go
+++ b/catalog/aws/aa_e2e/harness.go
@@ -121,6 +121,30 @@ func (h *Harness) VerifyDeployed(ctx context.Context, component string, outputs 
 	return v.VerifyExists(ctx, h.cfg, id, region)
 }
 
+// VerifyRuntimeFailureCause implements the framework's optional
+// RuntimeCauseVerifier capability (expected-runtime-failure lanes): it
+// dispatches to the kind's verifier, which must itself opt in via the local
+// verify.RuntimeCauseVerifier interface, reusing the outputs and region
+// VERIFY-RES stored (the phase is guaranteed to have run first).
+func (h *Harness) VerifyRuntimeFailureCause(ctx context.Context, tc *provider.ComponentTestContext, cause string) error {
+	v, err := verify.GetVerifier(tc.Component)
+	if err != nil {
+		return err
+	}
+	rcv, ok := v.(verify.RuntimeCauseVerifier)
+	if !ok {
+		return errors.Errorf("component %q's verifier does not implement verify.RuntimeCauseVerifier -- the scenario expects a runtime failure cause (%s) it cannot pin", tc.Component, cause)
+	}
+
+	h.mu.Lock()
+	res := h.deployed[componentKey(ctx, tc.Component)]
+	h.mu.Unlock()
+	if res.outputs == nil {
+		return errors.Errorf("no stored outputs for %s -- VERIFY-RES may not have run", tc.Component)
+	}
+	return rcv.VerifyRuntimeFailureCause(ctx, h.cfg, res.outputs, res.region, cause)
+}
+
 // VerifyDestroyed confirms the previously deployed resource no longer exists.
 func (h *Harness) VerifyDestroyed(ctx context.Context, component string) error {
 	v, err := verify.GetVerifier(component)

--- a/catalog/aws/aa_e2e/verify/planton_runner.go
+++ b/catalog/aws/aa_e2e/verify/planton_runner.go
@@ -2,8 +2,14 @@ package verify
 
 import (
 	"context"
+	"fmt"
+	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	"github.com/aws/aws-sdk-go-v2/service/ecs"
+	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	pkgerrors "github.com/pkg/errors"
 )
 
@@ -40,4 +46,103 @@ func (*plantonRunnerVerifier) VerifyAbsent(ctx context.Context, cfg aws.Config, 
 		return pkgerrors.Errorf("awsplantonrunner %q still ACTIVE after destroy", id)
 	}
 	return nil
+}
+
+// VerifyRuntimeFailureCause pins the fake-token task's designed failure to the
+// refused control-plane join and nothing else, with two independent AWS
+// evidence sources: the service's STOPPED task history must show a task whose
+// container RAN and exited non-zero (a pull failure reads `CannotPull...` in
+// the stopped reason -- the exact distinguisher, failed immediately and
+// loudly), and the task definition's CloudWatch log group must carry the
+// runner's join-step error line ("joining as runner ...") -- emitted only
+// after the process read the token from Secrets Manager and REACHED the
+// control plane. Polling is bounded: an ECS task needs a pull-run-exit cycle
+// (a couple of minutes) before its history and logs attest the cause.
+func (*plantonRunnerVerifier) VerifyRuntimeFailureCause(ctx context.Context, cfg aws.Config, outputs map[string]interface{}, region, cause string) error {
+	if cause != "refused-join" {
+		return pkgerrors.Errorf("unsupported runtime failure cause %q for the runner (supported: refused-join)", cause)
+	}
+
+	serviceArn, _ := outputs["service_arn"].(string)
+	logGroup, _ := outputs["log_group_name"].(string)
+	if serviceArn == "" || logGroup == "" {
+		return pkgerrors.New("service_arn or log_group_name missing from outputs -- cannot pin the runtime failure cause")
+	}
+	clusterName, serviceName, err := parseEcsServiceArn(serviceArn)
+	if err != nil {
+		return err
+	}
+
+	ecsClient := ecs.NewFromConfig(cfg, func(o *ecs.Options) {
+		if region != "" {
+			o.Region = region
+		}
+	})
+	logsClient := cloudwatchlogs.NewFromConfig(cfg, func(o *cloudwatchlogs.Options) {
+		if region != "" {
+			o.Region = region
+		}
+	})
+
+	deadline := time.Now().Add(5 * time.Minute)
+	ranAndExited := false
+	lastState := "no stopped task yet"
+	for {
+		if !ranAndExited {
+			stopped, listErr := ecsClient.ListTasks(ctx, &ecs.ListTasksInput{
+				Cluster:       &clusterName,
+				ServiceName:   &serviceName,
+				DesiredStatus: ecstypes.DesiredStatusStopped,
+			})
+			if listErr == nil && len(stopped.TaskArns) > 0 {
+				described, descErr := ecsClient.DescribeTasks(ctx, &ecs.DescribeTasksInput{
+					Cluster: &clusterName,
+					Tasks:   stopped.TaskArns,
+				})
+				if descErr == nil {
+					var states []string
+					for _, task := range described.Tasks {
+						reason := aws.ToString(task.StoppedReason)
+						if strings.Contains(reason, "CannotPull") {
+							return pkgerrors.Errorf("the runner task cannot PULL the image -- a registry problem, not the designed refused join: %s", reason)
+						}
+						for _, c := range task.Containers {
+							if strings.Contains(aws.ToString(c.Reason), "CannotPull") {
+								return pkgerrors.Errorf("the runner container cannot PULL the image -- a registry problem, not the designed refused join: %s", aws.ToString(c.Reason))
+							}
+							if c.ExitCode != nil && *c.ExitCode != 0 {
+								ranAndExited = true
+							}
+							exit := "<nil>"
+							if c.ExitCode != nil {
+								exit = fmt.Sprintf("%d", *c.ExitCode)
+							}
+							states = append(states, fmt.Sprintf("task stopped-reason=%q container reason=%q exit=%s", reason, aws.ToString(c.Reason), exit))
+						}
+					}
+					if !ranAndExited {
+						lastState = fmt.Sprintf("%d stopped task(s), none with a non-zero container exit yet: %s",
+							len(described.Tasks), strings.Join(states, " | "))
+					}
+				}
+			}
+		}
+
+		if ranAndExited {
+			events, logErr := logsClient.FilterLogEvents(ctx, &cloudwatchlogs.FilterLogEventsInput{
+				LogGroupName:  &logGroup,
+				FilterPattern: aws.String(`"joining as runner"`),
+			})
+			if logErr == nil && len(events.Events) > 0 {
+				fmt.Printf("  [verify] CAUSE: a task ran and exited non-zero (no pull failures) and %q carries the join-step error -- the ONLY failure is the refused join\n", logGroup)
+				return nil
+			}
+			lastState = "a task ran and exited non-zero; waiting for the join-step log line"
+		}
+
+		if time.Now().After(deadline) {
+			return pkgerrors.Errorf("the runner task never attested the refused join within the window; last state: %s", lastState)
+		}
+		time.Sleep(15 * time.Second)
+	}
 }

--- a/catalog/aws/aa_e2e/verify/verifier.go
+++ b/catalog/aws/aa_e2e/verify/verifier.go
@@ -32,6 +32,15 @@ type OutputsVerifier interface {
 	VerifyAbsentFromOutputs(ctx context.Context, cfg aws.Config, outputs map[string]interface{}, region string) error
 }
 
+// RuntimeCauseVerifier is the optional capability a verifier implements when
+// its kind's scenario deploys a workload DESIGNED to fail (the framework's
+// expected-runtime-failure lane): it must pin the failure to exactly the
+// expected cause with AWS's own evidence -- task histories and log events --
+// never merely tolerate "some failure".
+type RuntimeCauseVerifier interface {
+	VerifyRuntimeFailureCause(ctx context.Context, cfg aws.Config, outputs map[string]interface{}, region, cause string) error
+}
+
 // verifiers maps a component name to its verifier. New AWS components register
 // here as they are forged; today it carries the S3 walking-skeleton only.
 var verifiers = map[string]Verifier{

--- a/catalog/aws/awsplantonrunner/e2e/prerequisites/awssubnet.yaml
+++ b/catalog/aws/awsplantonrunner/e2e/prerequisites/awssubnet.yaml
@@ -1,0 +1,87 @@
+# Consumer-scoped AwsSubnet install profile for the runner appliance's
+# lanes: the SHARED subnet fixtures are bare (no route table, no internet
+# gateway anywhere in their chain), and a Fargate task on them has ZERO
+# egress -- it dies at ResourceInitializationError fetching the token from
+# Secrets Manager before the container ever starts (proven live; the image
+# pull and the control-plane join need the same egress). These overrides
+# keep the shared fixtures' NAMES (the scenario's references are untouched)
+# but each subnet owns a default route to the internet gateway fixture,
+# which each document pulls into the chain ahead of itself via its own
+# e2e-prerequisites annotation.
+# Paired with assignPublicIp: true on the scenario -- public-subnet egress
+# is the cheapest topology that gives the appliance its documented
+# outbound-only reach (production uses private subnets + NAT; the module's
+# GUIDE teaches that posture).
+apiVersion: aws.planton.dev/v1alpha1
+kind: AwsSubnet
+metadata:
+  name: planton-oss-e2e-awssubnet-prereq-a
+  id: planton-oss-e2e-awssubnet-prereq-a
+  org: planton-oss
+  env: e2e
+  labels:
+    managed-by: planton-e2e
+    e2e-component: awsplantonrunner
+  annotations:
+    planton.dev/e2e: "true"
+    # The subnet's default route references the internet gateway fixture, so
+    # this install manifest declares that edge itself -- the dependency
+    # resolver's DFS orders the gateway BEFORE these subnets from exactly
+    # this annotation.
+    planton.dev/e2e-prerequisites: "AwsInternetGateway"
+  tags:
+    - planton-e2e
+spec:
+  region: us-west-2
+  vpcId:
+    valueFrom:
+      kind: AwsVpc
+      name: planton-oss-e2e-awsvpc-prereq
+      fieldPath: status.outputs.vpc_id
+  availabilityZone: us-west-2a
+  cidrBlock: 10.0.101.0/24
+  routes:
+    - destinationCidrBlock: 0.0.0.0/0
+      targetType: internet_gateway
+      targetId:
+        valueFrom:
+          kind: AwsInternetGateway
+          name: planton-oss-e2e-awsinternetgateway-prereq
+          fieldPath: status.outputs.internet_gateway_id
+---
+apiVersion: aws.planton.dev/v1alpha1
+kind: AwsSubnet
+metadata:
+  name: planton-oss-e2e-awssubnet-prereq-b
+  id: planton-oss-e2e-awssubnet-prereq-b
+  org: planton-oss
+  env: e2e
+  labels:
+    managed-by: planton-e2e
+    e2e-component: awsplantonrunner
+  annotations:
+    planton.dev/e2e: "true"
+    # The subnet's default route references the internet gateway fixture, so
+    # this install manifest declares that edge itself -- the dependency
+    # resolver's DFS orders the gateway BEFORE these subnets from exactly
+    # this annotation.
+    planton.dev/e2e-prerequisites: "AwsInternetGateway"
+  tags:
+    - planton-e2e
+spec:
+  region: us-west-2
+  vpcId:
+    valueFrom:
+      kind: AwsVpc
+      name: planton-oss-e2e-awsvpc-prereq
+      fieldPath: status.outputs.vpc_id
+  availabilityZone: us-west-2b
+  cidrBlock: 10.0.102.0/24
+  routes:
+    - destinationCidrBlock: 0.0.0.0/0
+      targetType: internet_gateway
+      targetId:
+        valueFrom:
+          kind: AwsInternetGateway
+          name: planton-oss-e2e-awsinternetgateway-prereq
+          fieldPath: status.outputs.internet_gateway_id

--- a/catalog/aws/awsplantonrunner/e2e/profile.yaml
+++ b/catalog/aws/awsplantonrunner/e2e/profile.yaml
@@ -3,18 +3,20 @@ kind: ComponentE2EProfile
 metadata:
   name: awsplantonrunner
 spec:
-  # A runner appliance under live E2E: the harness deploys the VPC and
-  # two-AZ subnet prerequisites, then runs deploy -> DescribeServices
-  # verify (ACTIVE) -> destroy -> verify-inactive on both provisioners.
-  # The scenario supplies an obviously-fake runner token, so the container
-  # never joins any control plane -- deliberately: verification is
-  # service-level (ECS reports ACTIVE independently of task health, and
-  # the modules do not gate on steady state), which proves the full
-  # provisioning surface (token secret, both IAM roles, log group,
-  # outbound-only security group, dedicated cluster, task definition,
-  # Fargate service) and clean teardown without live credentials. The
-  # prerequisite subnets ride the VPC main route table (no internet
-  # route), so no task ever pulls the image or starts.
+  # A runner appliance under live E2E: the harness deploys the VPC,
+  # internet gateway, and two-AZ ROUTED subnet prerequisites (the
+  # consumer-scoped override -- a Fargate task needs real egress to fetch
+  # the token secret and pull the image before its container ever
+  # starts), then runs deploy -> DescribeServices verify (ACTIVE) ->
+  # VERIFY-CAUSE -> destroy -> verify-inactive on both provisioners. The
+  # scenario supplies an obviously-fake runner token, so the container's
+  # join is refused -- deliberately: beyond the service-level ACTIVE
+  # check (ECS reports ACTIVE independently of task health), the lane's
+  # VERIFY-CAUSE phase pins the designed failure with AWS's own evidence
+  # (a stopped task that RAN and exited non-zero with no pull failure,
+  # plus the runner's join-step error in the CloudWatch log group) so a
+  # pull error, a secret-fetch failure, or an argv defect fails the lane
+  # instead of hiding behind the crash-loop.
   tier: 1
   status: green
   validated_provisioners: [pulumi, terraform]

--- a/catalog/aws/awsplantonrunner/e2e/scenarios/minimal.yaml
+++ b/catalog/aws/awsplantonrunner/e2e/scenarios/minimal.yaml
@@ -1,8 +1,14 @@
-# Minimal AwsPlantonRunner scenario: the appliance on the two-AZ subnet
-# pair with an obviously-fake runner token (the container never joins any
-# control plane; see ../profile.yaml for why service-level verification
-# makes that the right lane shape). Full metadata is supplied for
-# tagging/orphan cleanup.
+# Minimal AwsPlantonRunner scenario: the appliance on a two-AZ ROUTED
+# subnet pair with an obviously-fake runner token. The task needs real
+# egress before any designed failure can even happen -- Fargate fetches
+# the token from Secrets Manager and pulls the image before the container
+# starts, and the shared bare subnets have no route out (proven live:
+# ResourceInitializationError before one container start). The
+# consumer-scoped prerequisites/awssubnet.yaml shadows the shared names
+# with internet-routed versions (each pulling the internet gateway into
+# the chain ahead of itself via its own annotation), and assignPublicIp
+# gives the tasks addresses the routes can carry. Full metadata is
+# supplied for tagging/orphan cleanup.
 apiVersion: aws.planton.dev/v1alpha1
 kind: AwsPlantonRunner
 metadata:
@@ -15,6 +21,11 @@ metadata:
     e2e-component: awsplantonrunner
   annotations:
     planton.dev/e2e: "true"
+    # The fake token's task crash-loop is DESIGNED -- the lane pins the
+    # failure to the refused control-plane join (a stopped task that ran and
+    # exited non-zero with no pull failure, plus the join-step error in the
+    # CloudWatch log group) and would fail on any other cause.
+    planton.dev/e2e-expected-runtime-failure: refused-join
   tags:
     - planton-e2e
 spec:
@@ -28,4 +39,5 @@ spec:
         kind: AwsSubnet
         name: planton-oss-e2e-awssubnet-prereq-b
         fieldPath: status.outputs.subnet_id
+  assignPublicIp: true
   token: prt_FAKE_E2E_PLACEHOLDER

--- a/catalog/azure/aa_e2e/harness.go
+++ b/catalog/azure/aa_e2e/harness.go
@@ -194,6 +194,30 @@ func (h *Harness) VerifyDeployed(ctx context.Context, component string, outputs 
 	return v.VerifyExists(ctx, h.cred, h.subscriptionID, id)
 }
 
+// VerifyRuntimeFailureCause implements the framework's optional
+// RuntimeCauseVerifier capability (expected-runtime-failure lanes): it
+// dispatches to the kind's verifier, which must itself opt in via the local
+// verify.RuntimeCauseVerifier interface, reusing the resource id VERIFY-RES
+// stored (the phase is guaranteed to have run first).
+func (h *Harness) VerifyRuntimeFailureCause(ctx context.Context, tc *provider.ComponentTestContext, cause string) error {
+	v, err := verify.GetVerifier(tc.Component)
+	if err != nil {
+		return err
+	}
+	rcv, ok := v.(verify.RuntimeCauseVerifier)
+	if !ok {
+		return errors.Errorf("component %q's verifier does not implement verify.RuntimeCauseVerifier -- the scenario expects a runtime failure cause (%s) it cannot pin", tc.Component, cause)
+	}
+
+	h.mu.Lock()
+	res := h.deployed[componentKey(ctx, tc.Component)]
+	h.mu.Unlock()
+	if res.id == "" {
+		return errors.Errorf("no stored resource id for %s -- VERIFY-RES may not have run", tc.Component)
+	}
+	return rcv.VerifyRuntimeFailureCause(ctx, h.cred, h.subscriptionID, res.id, cause)
+}
+
 // VerifyDestroyed confirms the previously deployed resource no longer exists.
 func (h *Harness) VerifyDestroyed(ctx context.Context, component string) error {
 	v, err := verify.GetVerifier(component)

--- a/catalog/azure/aa_e2e/verify/planton_runner.go
+++ b/catalog/azure/aa_e2e/verify/planton_runner.go
@@ -2,8 +2,11 @@ package verify
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	pkgerrors "github.com/pkg/errors"
 )
 
@@ -40,4 +43,61 @@ func (*plantonRunnerVerifier) VerifyAbsent(ctx context.Context, cred azcore.Toke
 		return pkgerrors.Errorf("azureplantonrunner %q still exists after destroy", id)
 	}
 	return nil
+}
+
+// VerifyRuntimeFailureCause pins the fake-token app's designed failure as far
+// as ARM's management plane can see. Reaching this phase at all proves the
+// image PULLED: Container Apps validates image pullability during the app
+// create (proven live -- an unpullable manifest fails the whole deployment),
+// and this phase only runs after a successful deploy. The revision state then
+// attests the container is failing by design: ARM marks a revision whose
+// container runs-and-exits (the refused join; the startup probe never passes)
+// as provisioningState=Failed with healthState=Unhealthy / runningState=Failed
+// -- the exact live-observed triple. The join-refusal SPECIFICITY -- that the
+// process exited on the join step and not something else -- is not readable
+// through ARM without a Log Analytics workspace (the consumption-only test
+// environment streams logs only), and is pinned by the Kubernetes and Cloud
+// Run lanes running the SAME binary and image; this assertion carries Azure's
+// share of the evidence honestly rather than claiming more than ARM exposes.
+func (*plantonRunnerVerifier) VerifyRuntimeFailureCause(ctx context.Context, cred azcore.TokenCredential, subscriptionID, id, cause string) error {
+	if cause != "refused-join" {
+		return pkgerrors.Errorf("unsupported runtime failure cause %q for the runner (supported: refused-join)", cause)
+	}
+
+	client, err := armresources.NewClient(subscriptionID, cred, nil)
+	if err != nil {
+		return err
+	}
+
+	deadline := time.Now().Add(3 * time.Minute)
+	lastState := "no revision state read yet"
+	for {
+		app, err := client.GetByID(ctx, id, containerAppsAPIVersion, nil)
+		if err != nil {
+			return pkgerrors.Wrapf(err, "reading the app for revision state (%q)", id)
+		}
+		if props, ok := app.Properties.(map[string]interface{}); ok {
+			if rev, ok := props["latestRevisionName"].(string); ok && rev != "" {
+				revResp, revErr := client.GetByID(ctx, id+"/revisions/"+rev, containerAppsAPIVersion, nil)
+				if revErr == nil {
+					if rp, ok := revResp.Properties.(map[string]interface{}); ok {
+						provisioning, _ := rp["provisioningState"].(string)
+						health, _ := rp["healthState"].(string)
+						running, _ := rp["runningState"].(string)
+						lastState = fmt.Sprintf("revision %s: provisioningState=%s healthState=%s runningState=%s",
+							rev, provisioning, health, running)
+						if health == "Unhealthy" || running == "Degraded" || running == "Failed" {
+							fmt.Printf("  [verify] CAUSE: %s -- the image pulled (create validates pullability; this phase presupposes a successful deploy) and the container is failing by design\n", lastState)
+							return nil
+						}
+					}
+				}
+			}
+		}
+
+		if time.Now().After(deadline) {
+			return pkgerrors.Errorf("the runner revision never attested the designed running-and-failing state within the window; last: %s", lastState)
+		}
+		time.Sleep(10 * time.Second)
+	}
 }

--- a/catalog/azure/aa_e2e/verify/verifier.go
+++ b/catalog/azure/aa_e2e/verify/verifier.go
@@ -26,6 +26,14 @@ type Verifier interface {
 	VerifyAbsent(ctx context.Context, cred azcore.TokenCredential, subscriptionID, id string) error
 }
 
+// RuntimeCauseVerifier is the optional capability a verifier implements when
+// its kind's scenario deploys a workload DESIGNED to fail (the framework's
+// expected-runtime-failure lane): it must pin the failure to the expected
+// cause with ARM's own evidence, never merely tolerate "some failure".
+type RuntimeCauseVerifier interface {
+	VerifyRuntimeFailureCause(ctx context.Context, cred azcore.TokenCredential, subscriptionID, id, cause string) error
+}
+
 // verifiers maps a component name to its verifier. New Azure components register
 // here as they are forged.
 var verifiers = map[string]Verifier{

--- a/catalog/azure/azureplantonrunner/e2e/profile.yaml
+++ b/catalog/azure/azureplantonrunner/e2e/profile.yaml
@@ -16,7 +16,11 @@ spec:
   # and fails the whole deployment on MANIFEST_UNKNOWN (proven live, both
   # boundaries) -- so this lane also proves the published :latest image
   # serves linux/amd64. Measured lanes ~11-12 min/engine, dominated by the
-  # fixture environment's ~8 min teardown.
+  # fixture environment's ~8 min teardown. The lane's VERIFY-CAUSE phase
+  # additionally attests the replica RAN and is failing by design (ARM
+  # marks the crash-looping revision provisioningState=Failed /
+  # healthState=Unhealthy); the join-refusal specificity is pinned by the
+  # Kubernetes and Cloud Run lanes running the same binary and image.
   tier: 1
   status: green
   validated_provisioners: [pulumi, terraform]

--- a/catalog/azure/azureplantonrunner/e2e/scenarios/minimal.yaml
+++ b/catalog/azure/azureplantonrunner/e2e/scenarios/minimal.yaml
@@ -16,6 +16,10 @@ metadata:
     e2e-component: azureplantonrunner
   annotations:
     planton.dev/e2e: "true"
+    # The fake token's replica crash-loop is DESIGNED -- the lane additionally
+    # pins the failure as far as ARM sees it: the revision provisioned (the
+    # image pulled; create validates pullability) while running-and-failing.
+    planton.dev/e2e-expected-runtime-failure: refused-join
   tags:
     - planton-e2e
 spec:

--- a/catalog/gcp/aa_e2e/BUILD.bazel
+++ b/catalog/gcp/aa_e2e/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//catalog/gcp/aa_e2e/verify",
         "//e2e/framework/provider",
         "@com_github_pkg_errors//:errors",
+        "@io_k8s_sigs_yaml//:yaml",
         "@org_golang_google_api//alloydb/v1:alloydb",
         "@org_golang_google_api//artifactregistry/v1:artifactregistry",
         "@org_golang_google_api//bigquery/v2:bigquery",

--- a/catalog/gcp/aa_e2e/harness.go
+++ b/catalog/gcp/aa_e2e/harness.go
@@ -60,6 +60,7 @@ import (
 	"google.golang.org/api/storage/v1"
 	"google.golang.org/api/vpcaccess/v1"
 	workflows "google.golang.org/api/workflows/v1"
+	"sigs.k8s.io/yaml"
 )
 
 // Harness manages the GCP E2E test lifecycle.
@@ -352,6 +353,64 @@ func (h *Harness) VerifyDestroyed(ctx context.Context, component string) error {
 		return errors.Errorf("no stored outputs for %s -- VerifyDeployed may not have run", component)
 	}
 	return v.VerifyAbsent(ctx, h.services, outputs)
+}
+
+// VerifyExpectedDeployFailure implements the framework's optional
+// DeployFailureVerifier capability (expected-deploy-failure lanes, for
+// substrates that gate resource creation on workload health). Stack outputs
+// do not exist on a failed deploy, so identity comes from the scenario
+// manifest: the service name (metadata.name) and region (spec.region). The
+// kind's verifier must itself opt in via the local
+// verify.DeployFailureVerifier interface.
+func (h *Harness) VerifyExpectedDeployFailure(ctx context.Context, tc *provider.ComponentTestContext, expectation string, deployErr error) error {
+	v, err := verify.GetVerifier(tc.Component)
+	if err != nil {
+		return err
+	}
+	dfv, ok := v.(verify.DeployFailureVerifier)
+	if !ok {
+		return errors.Errorf("component %q's verifier does not implement verify.DeployFailureVerifier -- the scenario expects a deploy failure (%s) it cannot attribute", tc.Component, expectation)
+	}
+
+	manifestPath, _ := ctx.Value(provider.ManifestPathKey{}).(string)
+	if manifestPath == "" {
+		manifestPath = tc.ManifestPath
+	}
+	raw, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return errors.Wrap(err, "reading the scenario manifest for failure attribution")
+	}
+	var manifest struct {
+		Metadata struct {
+			Name string `json:"name"`
+		} `json:"metadata"`
+		Spec struct {
+			Region string `json:"region"`
+		} `json:"spec"`
+	}
+	if err := yaml.Unmarshal(raw, &manifest); err != nil {
+		return errors.Wrap(err, "parsing the scenario manifest for failure attribution")
+	}
+	if manifest.Metadata.Name == "" || manifest.Spec.Region == "" {
+		return errors.Errorf("the scenario manifest must carry metadata.name and spec.region for failure attribution (got name=%q region=%q)",
+			manifest.Metadata.Name, manifest.Spec.Region)
+	}
+	if err := dfv.VerifyExpectedDeployFailure(ctx, h.services, manifest.Metadata.Name, manifest.Spec.Region, expectation, deployErr); err != nil {
+		return err
+	}
+
+	// Store the manifest-derived identity where VerifyDeployed would have:
+	// the expected-failure lifecycle has no VERIFY-RES, but its VERIFY-CLN
+	// still must prove the destroyed-after-failed-create resource is GONE,
+	// through the same absence probe every normal lane uses.
+	h.mu.Lock()
+	h.deployed[componentKey(ctx, tc.Component)] = map[string]string{
+		"service_short_name": manifest.Metadata.Name,
+		"region":             manifest.Spec.Region,
+		"project_id":         h.services.Project,
+	}
+	h.mu.Unlock()
+	return nil
 }
 
 // stringOutputs flattens stack outputs to strings, tolerating non-string scalars.

--- a/catalog/gcp/aa_e2e/verify/planton_runner.go
+++ b/catalog/gcp/aa_e2e/verify/planton_runner.go
@@ -3,10 +3,23 @@ package verify
 import (
 	"context"
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"google.golang.org/api/googleapi"
+	"google.golang.org/api/logging/v2"
 )
+
+// firstLines truncates multi-line evidence to its first n lines -- enough to
+// attribute a failure without flooding the phase output.
+func firstLines(out string, n int) string {
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) > n {
+		lines = lines[:n]
+	}
+	return strings.Join(lines, "\n")
+}
 
 // plantonRunnerVerifier probes a Planton runner appliance via the Run
 // Admin API v2. The appliance is a single-instance Cloud Run service, so
@@ -83,4 +96,104 @@ func (v *plantonRunnerVerifier) VerifyAbsent(ctx context.Context, svc *Services,
 		return nil
 	}
 	return errors.Wrapf(err, "unexpected error probing planton runner service %s after destroy", path)
+}
+
+// VerifyExpectedDeployFailure proves a fake-token deploy failed for EXACTLY
+// the designed reason on the one substrate that gates creation on workload
+// health. Three assertions, each with the provider's own evidence:
+//
+//  1. The engine's error is the revision-readiness class (Cloud Run refused
+//     to finish creating a service whose first revision never turned ready)
+//     -- a quota, permission, or image-pull failure fails here with the full
+//     error text.
+//  2. The Service OBJECT exists with the full authored template despite the
+//     failed create: the token wired as a secret reference (never a plain
+//     env value) and scaling pinned to exactly one instance -- proving the
+//     module composed everything correctly and only readiness failed.
+//  3. Cloud Logging carries the runner's own join-step error ("joining as
+//     runner ...") for this service -- emitted only after the process read
+//     the token from Secret Manager and REACHED the control plane. A
+//     "dialing control-plane" line instead means network, not the token, and
+//     the phase fails with that evidence. Log ingestion lags by seconds, so
+//     the read polls bounded.
+func (v *plantonRunnerVerifier) VerifyExpectedDeployFailure(ctx context.Context, svc *Services, serviceName, region, expectation string, deployErr error) error {
+	if expectation != "revision-readiness" {
+		return errors.Errorf("unsupported deploy-failure expectation %q for the runner (supported: revision-readiness)", expectation)
+	}
+
+	// 1. Classify the engine error: both engines surface Cloud Run's own
+	// revision-readiness failure; anything else is NOT the designed failure.
+	// The live phrasing (both engines, proven): "The user-provided container
+	// failed the configured startup probe checks" -- the runner ran, its join
+	// was refused, it exited, and the probe never answered. The Ready-
+	// condition phrasings cover other provider versions of the same class.
+	errText := deployErr.Error()
+	readinessClass := strings.Contains(errText, "startup probe") ||
+		strings.Contains(errText, "not ready") ||
+		strings.Contains(errText, "Ready") ||
+		strings.Contains(errText, "RevisionFailed")
+	if !readinessClass {
+		return errors.Errorf("the deploy failed, but not with the revision-readiness class this scenario designs for; engine error: %s", firstLines(errText, 8))
+	}
+
+	path := fmt.Sprintf("projects/%s/locations/%s/services/%s", svc.Project, region, serviceName)
+
+	// 2. The service object survived the failed create with the authored
+	// template intact.
+	service, err := svc.Run.Projects.Locations.Services.Get(path).Context(ctx).Do()
+	if err != nil {
+		return errors.Wrapf(err, "the failed create should leave the service object inspectable, but %s is not readable", path)
+	}
+	if service.Template == nil || service.Template.Scaling == nil ||
+		service.Template.Scaling.MinInstanceCount != 1 || service.Template.Scaling.MaxInstanceCount != 1 {
+		return errors.Errorf("service %s must pin scaling to exactly one instance even in the failed-create state", path)
+	}
+	tokenWiredAsSecret := false
+	for _, c := range service.Template.Containers {
+		for _, env := range c.Env {
+			if env.Name == "PLANTON_RUNNER_TOKEN" && env.ValueSource != nil && env.ValueSource.SecretKeyRef != nil {
+				tokenWiredAsSecret = true
+			}
+		}
+	}
+	if !tokenWiredAsSecret {
+		return errors.Errorf("service %s must carry PLANTON_RUNNER_TOKEN as a secret reference (never a plain env value)", path)
+	}
+
+	// 3. Pin the cause from the workload's own log line.
+	filter := fmt.Sprintf(`resource.type="cloud_run_revision" AND resource.labels.service_name=%q AND resource.labels.location=%q AND timestamp>=%q`,
+		serviceName, region, time.Now().Add(-30*time.Minute).UTC().Format(time.RFC3339))
+	deadline := time.Now().Add(3 * time.Minute)
+	lastState := "no log entries read yet"
+	for {
+		resp, logErr := svc.Logging.Entries.List(&logging.ListLogEntriesRequest{
+			ResourceNames: []string{"projects/" + svc.Project},
+			Filter:        filter,
+			OrderBy:       "timestamp desc",
+			PageSize:      200,
+		}).Context(ctx).Do()
+		if logErr == nil {
+			var dialing bool
+			for _, entry := range resp.Entries {
+				if strings.Contains(entry.TextPayload, "joining as runner") {
+					fmt.Printf("  [verify] CAUSE: deploy failed at revision readiness, the service object carries the full authored template, and Cloud Logging holds the join-step error -- the ONLY failure is the refused join\n")
+					return nil
+				}
+				if strings.Contains(entry.TextPayload, "dialing control-plane") {
+					dialing = true
+				}
+			}
+			if dialing {
+				return errors.New("the runner failed DIALING the control plane (network), not joining with the token")
+			}
+			lastState = fmt.Sprintf("%d log entries, none carrying the join line yet", len(resp.Entries))
+		} else {
+			lastState = logErr.Error()
+		}
+
+		if time.Now().After(deadline) {
+			return errors.Errorf("Cloud Logging never surfaced the runner's join-step error within the window; last state: %s", lastState)
+		}
+		time.Sleep(10 * time.Second)
+	}
 }

--- a/catalog/gcp/aa_e2e/verify/verifier.go
+++ b/catalog/gcp/aa_e2e/verify/verifier.go
@@ -111,6 +111,19 @@ type Verifier interface {
 	VerifyAbsent(ctx context.Context, svc *Services, outputs map[string]string) error
 }
 
+// DeployFailureVerifier is the optional capability a verifier implements when
+// its kind's scenario EXPECTS the deploy to fail (the framework's
+// expected-deploy-failure lane, for substrates that gate resource creation on
+// workload health — Cloud Run gates service creation on first-revision
+// readiness). Stack outputs do not exist when this runs: identity arrives as
+// the manifest-derived service name and region. Implementations must classify
+// the engine's error, assert the partially-created resource's state with the
+// provider's own APIs, and pin the workload's failure cause from its logs —
+// never merely tolerate "some failure".
+type DeployFailureVerifier interface {
+	VerifyExpectedDeployFailure(ctx context.Context, svc *Services, serviceName, region, expectation string, deployErr error) error
+}
+
 // verifiers maps a component name to its verifier. New GCP components register
 // here as they are forged.
 var verifiers = map[string]Verifier{

--- a/catalog/gcp/gcpplantonrunner/e2e/profile.yaml
+++ b/catalog/gcp/gcpplantonrunner/e2e/profile.yaml
@@ -3,14 +3,23 @@ kind: ComponentE2EProfile
 metadata:
   name: gcpplantonrunner
 spec:
-  # A runner appliance under live E2E: deploy -> service-exists verify ->
-  # destroy -> verify-absent on both provisioners. Cloud Run v2 gates
-  # service CREATION on the first revision becoming ready, and the runner
-  # only stays up after a successful control-plane join -- so the lane
-  # needs an owner-arranged real runner token (the scenario's fenced
-  # PLANTON_E2E_RUNNER_TOKEN env; lanes SKIP with the reason when it is
-  # absent). This is a substrate property, not a module gap: the same
-  # module deploys cleanly the moment the token is real.
+  # A runner appliance under live E2E, proven in TWO halves:
+  #
+  # 1. PROVEN (both provisioners, live): the fake-token-failure-mode
+  #    scenario -- Cloud Run v2 gates service CREATION on the first
+  #    revision becoming ready, and a runner whose join is refused exits,
+  #    so the lane deploys EXPECTING failure and pins the cause with the
+  #    provider's own evidence (the readiness-class engine error, the
+  #    service object carrying the full authored template, and the
+  #    runner's join-step error in Cloud Logging), then destroys and
+  #    verifies absence. Everything except "revision goes ready on a
+  #    successful join" is live-proven, with zero secrets, forever
+  #    CI-runnable.
+  # 2. PENDING: the ready-state half -- the minimal scenario needs an
+  #    owner-arranged real runner token (the fenced
+  #    PLANTON_E2E_RUNNER_TOKEN env; lanes SKIP with the reason when it
+  #    is absent). One run with a throwaway token flips this profile
+  #    green; this is a substrate property, not a module gap.
   tier: 1
   status: pending_proof
   validated_provisioners: []

--- a/catalog/gcp/gcpplantonrunner/e2e/scenarios/fake-token-failure-mode.yaml
+++ b/catalog/gcp/gcpplantonrunner/e2e/scenarios/fake-token-failure-mode.yaml
@@ -1,0 +1,29 @@
+# Failure-mode GcpPlantonRunner scenario: the appliance with an
+# obviously-fake runner token, EXPECTING the deploy to fail. Cloud Run v2
+# gates service creation on the first revision becoming ready, and a
+# runner whose join is refused exits -- so on this substrate the fake
+# token's designed failure surfaces at CREATE, not at runtime. The lane
+# proves the failure is exactly that: the engine error carries the
+# revision-readiness class, the service object survives with the full
+# authored template (token as a secret reference, single-instance
+# scaling), and Cloud Logging holds the runner's own join-step error.
+# This scenario needs NO secret and runs forever in CI; the sibling
+# `minimal` scenario (fenced on a real token) proves the ready-state half.
+apiVersion: gcp.planton.dev/v1alpha1
+kind: GcpPlantonRunner
+metadata:
+  name: planton-oss-e2e-gcp-runner-fm
+  id: planton-oss-e2e-gcp-runner-fm
+  org: planton-oss
+  env: e2e
+  labels:
+    managed-by: planton-e2e
+    e2e-component: gcpplantonrunner
+  annotations:
+    planton.dev/e2e: "true"
+    planton.dev/e2e-expect-deploy-failure: revision-readiness
+  tags:
+    - planton-e2e
+spec:
+  region: us-central1
+  token: prt_FAKE_E2E_PLACEHOLDER

--- a/catalog/gcp/gcpplantonrunner/iac/pulumi/module/service.go
+++ b/catalog/gcp/gcpplantonrunner/iac/pulumi/module/service.go
@@ -82,11 +82,11 @@ func runnerService(
 			Value: pulumi.String(spec.GetControlPlaneEndpoint()),
 		})
 	}
+	// NO explicit PORT env: Cloud Run reserves the name and rejects the whole
+	// create with a 400 when a template sets it (proven live). The platform
+	// injects PORT itself from the ports block's ContainerPort, which is how
+	// the runner's server learns its port here.
 	envs = append(envs,
-		&cloudrunv2.ServiceTemplateContainerEnvArgs{
-			Name:  pulumi.String("PORT"),
-			Value: pulumi.Sprintf("%d", grpcPort),
-		},
 		&cloudrunv2.ServiceTemplateContainerEnvArgs{
 			Name:  pulumi.String("LOG_LEVEL"),
 			Value: pulumi.String("info"),
@@ -94,8 +94,14 @@ func runnerService(
 	)
 
 	container := &cloudrunv2.ServiceTemplateContainerArgs{
-		Image:    pulumi.Sprintf("%s:%s", spec.GetImageRepository(), spec.GetRunnerVersion()),
-		Commands: pulumi.ToStringArray([]string{"start"}),
+		Image: pulumi.Sprintf("%s:%s", spec.GetImageRepository(), spec.GetRunnerVersion()),
+		// Args, NEVER Commands: Cloud Run's command field REPLACES the image
+		// entrypoint (the runner binary), so Commands=["start"] makes the
+		// platform exec a binary literally named "start" -- the instance dies
+		// with "Application exec likely failed" before one log line (proven
+		// live). The image's entrypoint is the bare runner binary; the
+		// subcommand rides Args.
+		Args: pulumi.ToStringArray([]string{"start"}),
 		// h2c: the runner's server speaks plaintext HTTP/2 (gRPC) behind
 		// Cloud Run's TLS edge.
 		Ports: &cloudrunv2.ServiceTemplateContainerPortsArgs{

--- a/catalog/gcp/gcpplantonrunner/iac/tf/main.tf
+++ b/catalog/gcp/gcpplantonrunner/iac/tf/main.tf
@@ -149,8 +149,14 @@ resource "google_cloud_run_v2_service" "runner" {
     }
 
     containers {
-      image   = "${var.spec.image_repository}:${var.spec.runner_version}"
-      command = ["start"]
+      image = "${var.spec.image_repository}:${var.spec.runner_version}"
+      # args, NEVER command: Cloud Run's `command` REPLACES the image
+      # entrypoint (the runner binary), so command=["start"] makes the
+      # platform exec a binary literally named "start" -- the instance dies
+      # with "Application exec likely failed" before one log line (proven
+      # live). The image's entrypoint is the bare runner binary; the
+      # subcommand rides args.
+      args = ["start"]
 
       # h2c: the runner's server speaks plaintext HTTP/2 (gRPC) behind
       # Cloud Run's TLS edge.
@@ -192,10 +198,10 @@ resource "google_cloud_run_v2_service" "runner" {
           value = env.value
         }
       }
-      env {
-        name  = "PORT"
-        value = "50051"
-      }
+      # NO explicit PORT env: Cloud Run reserves the name and rejects the
+      # whole create with a 400 when a template sets it (proven live). The
+      # platform injects PORT itself from the ports block's container_port
+      # above, which is how the runner's server learns its port here.
       env {
         name  = "LOG_LEVEL"
         value = "info"

--- a/catalog/kubernetes/aa_e2e/harness.go
+++ b/catalog/kubernetes/aa_e2e/harness.go
@@ -343,6 +343,26 @@ func (h *Harness) VerifyDeployed(ctx context.Context, component string, outputs 
 	return verifier.VerifyExists(ctx, h.kubeconfigPath)
 }
 
+// VerifyRuntimeFailureCause implements the framework's optional
+// RuntimeCauseVerifier capability (expected-runtime-failure lanes): it
+// dispatches to the kind's verifier, which must itself opt in via the local
+// verify.RuntimeCauseVerifier interface.
+func (h *Harness) VerifyRuntimeFailureCause(ctx context.Context, tc *provider.ComponentTestContext, cause string) error {
+	manifestPath, _ := ctx.Value(provider.ManifestPathKey{}).(string)
+	if manifestPath == "" {
+		manifestPath = tc.ManifestPath
+	}
+	verifier, err := verify.GetVerifierFromManifest(manifestPath)
+	if err != nil {
+		return err
+	}
+	rcv, ok := verifier.(verify.RuntimeCauseVerifier)
+	if !ok {
+		return errors.Errorf("component %q's verifier does not implement verify.RuntimeCauseVerifier -- the scenario expects a runtime failure cause (%s) it cannot pin", tc.Component, cause)
+	}
+	return rcv.VerifyRuntimeFailureCause(ctx, h.kubeconfigPath, cause)
+}
+
 // VerifyDestroyed confirms that resources have been removed after destroy.
 func (h *Harness) VerifyDestroyed(ctx context.Context, component string) error {
 	manifestPath, _ := ctx.Value(provider.ManifestPathKey{}).(string)

--- a/catalog/kubernetes/aa_e2e/verify/plantonrunner.go
+++ b/catalog/kubernetes/aa_e2e/verify/plantonrunner.go
@@ -2,9 +2,12 @@ package verify
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os/exec"
+	"sort"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 )
@@ -90,4 +93,146 @@ func (v *PlantonRunnerVerifier) VerifyAbsent(ctx context.Context, kubeconfig str
 	}
 	fmt.Printf("  [verify] DESTROY: the runner Deployment and its token Secret are gone\n")
 	return nil
+}
+
+// VerifyRuntimeFailureCause pins the fake-token pod's designed failure to the
+// refused control-plane join and nothing else: the container's status must
+// prove the image PULLED and the process RAN (a non-zero terminated state or
+// a restart, never ImagePullBackOff/ErrImagePull), and the pod's own log must
+// carry the runner's join-step error ("joining as runner ...") -- the line the
+// binary emits only after it read the token from the Secret and REACHED the
+// control plane. A "dialing control-plane" line instead means the failure is
+// network, not the token, and the phase fails with that evidence.
+//
+// Polling is bounded: a fresh pod needs a restart or two before its status
+// and logs attest the cause.
+func (v *PlantonRunnerVerifier) VerifyRuntimeFailureCause(ctx context.Context, kubeconfig, cause string) error {
+	if cause != "refused-join" {
+		return errors.Errorf("unsupported runtime failure cause %q for the runner (supported: refused-join)", cause)
+	}
+
+	deadline := time.Now().Add(3 * time.Minute)
+	var lastState string
+	for {
+		podName, stateErr := v.crashedRunnerPod(ctx, kubeconfig)
+		if stateErr == nil && podName != "" {
+			// The container ran and exited; now pin WHY from its own log.
+			logOut, _ := exec.CommandContext(ctx, "kubectl", "--kubeconfig", kubeconfig,
+				"logs", podName, "-n", v.Namespace, "--tail", "50").CombinedOutput()
+			logs := string(logOut)
+			if !strings.Contains(logs, "joining as runner") {
+				// The crash may predate log capture on this restart; try the
+				// previous container instance before deciding.
+				prevOut, _ := exec.CommandContext(ctx, "kubectl", "--kubeconfig", kubeconfig,
+					"logs", podName, "-n", v.Namespace, "--previous", "--tail", "50").CombinedOutput()
+				logs = string(prevOut)
+			}
+			switch {
+			case strings.Contains(logs, "joining as runner"):
+				fmt.Printf("  [verify] CAUSE: image pulled, container ran, and the log carries the join-step error -- the ONLY failure is the refused join\n")
+				return nil
+			case strings.Contains(logs, "dialing control-plane"):
+				return errors.Errorf("the runner failed DIALING the control plane (network), not joining with the token -- pod %s logs: %s",
+					podName, firstLines(logs, 5))
+			}
+			lastState = fmt.Sprintf("pod %s crashed but its log does not yet carry the join line: %s", podName, firstLines(logs, 3))
+		} else if stateErr != nil {
+			lastState = stateErr.Error()
+		}
+
+		if time.Now().After(deadline) {
+			return errors.Errorf("the runner pod never attested the refused join within the window; last state: %s", lastState)
+		}
+		time.Sleep(10 * time.Second)
+	}
+}
+
+// crashedRunnerPod finds the runner Deployment's pod and returns its name once
+// its container status proves the image pulled and the process ran-and-exited.
+// An image-pull failure state fails IMMEDIATELY -- that is a registry problem
+// wearing a crash costume, never the designed refused join.
+func (v *PlantonRunnerVerifier) crashedRunnerPod(ctx context.Context, kubeconfig string) (string, error) {
+	// The chart's Deployment selects its pods by the Helm instance label
+	// (fullnameOverride pins names, not labels, so read the selector from
+	// the live Deployment rather than assuming label conventions).
+	selOut, err := exec.CommandContext(ctx, "kubectl", "--kubeconfig", kubeconfig,
+		"get", "deployment", v.Name, "-n", v.Namespace,
+		"-o", "jsonpath={.spec.selector.matchLabels}").CombinedOutput()
+	if err != nil {
+		return "", errors.Wrapf(err, "reading the Deployment selector: %s", firstLines(string(selOut), 3))
+	}
+	var labels map[string]string
+	if err := json.Unmarshal(selOut, &labels); err != nil {
+		return "", errors.Wrapf(err, "parsing the Deployment selector %q", string(selOut))
+	}
+	var selector []string
+	for k, val := range labels {
+		selector = append(selector, k+"="+val)
+	}
+	sort.Strings(selector)
+
+	podsOut, err := exec.CommandContext(ctx, "kubectl", "--kubeconfig", kubeconfig,
+		"get", "pods", "-n", v.Namespace, "-l", strings.Join(selector, ","),
+		"-o", "json").CombinedOutput()
+	if err != nil {
+		return "", errors.Wrapf(err, "listing the runner pods: %s", firstLines(string(podsOut), 3))
+	}
+
+	var podList struct {
+		Items []struct {
+			Metadata struct {
+				Name string `json:"name"`
+			} `json:"metadata"`
+			Status struct {
+				ContainerStatuses []struct {
+					ImageID      string `json:"imageID"`
+					RestartCount int    `json:"restartCount"`
+					State        struct {
+						Waiting *struct {
+							Reason string `json:"reason"`
+						} `json:"waiting"`
+						Terminated *struct {
+							ExitCode int `json:"exitCode"`
+						} `json:"terminated"`
+					} `json:"state"`
+					LastState struct {
+						Terminated *struct {
+							ExitCode int `json:"exitCode"`
+						} `json:"terminated"`
+					} `json:"lastState"`
+				} `json:"containerStatuses"`
+			} `json:"status"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(podsOut, &podList); err != nil {
+		return "", errors.Wrap(err, "parsing the runner pod list")
+	}
+	if len(podList.Items) == 0 {
+		return "", errors.New("no runner pod scheduled yet")
+	}
+
+	pod := podList.Items[0]
+	if len(pod.Status.ContainerStatuses) == 0 {
+		return "", errors.Errorf("pod %s has no container status yet", pod.Metadata.Name)
+	}
+	cs := pod.Status.ContainerStatuses[0]
+
+	if cs.State.Waiting != nil {
+		switch cs.State.Waiting.Reason {
+		case "ErrImagePull", "ImagePullBackOff":
+			return "", errors.Errorf("pod %s cannot PULL the image (%s) -- a registry problem, not the designed refused join",
+				pod.Metadata.Name, cs.State.Waiting.Reason)
+		}
+	}
+	if cs.ImageID == "" {
+		return "", errors.Errorf("pod %s has not pulled the image yet", pod.Metadata.Name)
+	}
+
+	ranAndExited := cs.RestartCount >= 1 ||
+		(cs.State.Terminated != nil && cs.State.Terminated.ExitCode != 0) ||
+		(cs.LastState.Terminated != nil && cs.LastState.Terminated.ExitCode != 0)
+	if !ranAndExited {
+		return "", errors.Errorf("pod %s has not exited yet (restarts=%d)", pod.Metadata.Name, cs.RestartCount)
+	}
+	return pod.Metadata.Name, nil
 }

--- a/catalog/kubernetes/aa_e2e/verify/verifier.go
+++ b/catalog/kubernetes/aa_e2e/verify/verifier.go
@@ -11,6 +11,15 @@ type ResourceVerifier interface {
 	VerifyAbsent(ctx context.Context, kubeconfig string) error
 }
 
+// RuntimeCauseVerifier is the optional capability a verifier implements when
+// its kind's scenario deploys a workload DESIGNED to fail (the framework's
+// expected-runtime-failure lane): it must pin the failure to exactly the
+// expected cause with the cluster's own evidence -- pod states and pod logs --
+// never merely tolerate "some failure".
+type RuntimeCauseVerifier interface {
+	VerifyRuntimeFailureCause(ctx context.Context, kubeconfig, cause string) error
+}
+
 // operatorKinds lists manifest kind values (lowercased) for operator/controller
 // components. Operators install CRD controllers that watch resources but typically
 // do not expose a Kubernetes Service. Verification checks namespace + running

--- a/catalog/kubernetes/kubernetesplantonrunner/e2e/profile.yaml
+++ b/catalog/kubernetes/kubernetesplantonrunner/e2e/profile.yaml
@@ -6,14 +6,17 @@ spec:
   # A runner under live E2E on the kind cluster: deploy -> verify the
   # release's install surface (the Deployment with replicas 1 and the
   # Recreate strategy, the module-created token Secret, the enrollment env
-  # wiring on the pod template) -> destroy -> verify-absent, on both
-  # provisioners. The scenario supplies an obviously-fake runner token,
-  # so the pod's join is refused and it restarts -- deliberately: the
-  # module installs with no Helm wait (the runner's readiness contract is
-  # its work queue, not pod liveness), so install-level verification
-  # proves the full chart contract and clean teardown without a reachable
-  # control plane.
+  # wiring on the pod template) -> verify the RUNTIME CAUSE -> destroy ->
+  # verify-absent, on both provisioners. The scenario supplies an
+  # obviously-fake runner token, so the pod's join is refused and it
+  # restarts -- deliberately: the module installs with no Helm wait (the
+  # runner's readiness contract is its work queue, not pod liveness), and
+  # the lane's VERIFY-CAUSE phase pins the designed failure with the
+  # cluster's own evidence (image pulled, container ran, the join-step
+  # error in the pod's log) so any OTHER failure -- a pull error, an
+  # argv/entrypoint defect -- fails the lane instead of hiding behind the
+  # crash-loop.
   tier: 1
-  status: pending_proof
-  validated_provisioners: []
+  status: green
+  validated_provisioners: [pulumi, terraform]
   timeout_minutes: 30

--- a/catalog/kubernetes/kubernetesplantonrunner/e2e/scenarios/minimal.yaml
+++ b/catalog/kubernetes/kubernetesplantonrunner/e2e/scenarios/minimal.yaml
@@ -15,6 +15,10 @@ metadata:
     e2e-component: kubernetesplantonrunner
   annotations:
     planton.dev/e2e: "true"
+    # The fake token's crash-loop is DESIGNED -- the lane pins the failure to
+    # the refused control-plane join (image pulled, container ran, the join
+    # error in the pod's own log) and would fail on any other cause.
+    planton.dev/e2e-expected-runtime-failure: refused-join
   tags:
     - planton-e2e
 spec:

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -393,6 +393,52 @@ Rules that keep the seam honest:
   that uses `[MLmodel]=` as an array key dies as "unbound variable"
   before any fetch (live-caught on the first SETUP-phase lane).
 
+### Failure-mode lanes: a deliberate failure as machine-verified evidence
+
+Some scenarios PROVE by failing: a component deployed with a credential a
+real service rejects (the canonical case: a Planton runner appliance with a
+fake enrollment token). The framework carries two annotation-activated
+shapes, both dispatching to optional harness capabilities
+(`provider.DeployFailureVerifier` / `provider.RuntimeCauseVerifier`,
+implemented per kind through each provider's verify registry):
+
+- **`planton.dev/e2e-expect-deploy-failure: <class>`** for substrates that
+  gate resource creation on workload health (Cloud Run gates service
+  creation on first-revision readiness). The lifecycle becomes VALIDATE ->
+  DEPLOY-EXPECT-FAIL -> DESTROY -> VERIFY-CLN: the deploy MUST fail, the
+  harness classifies the engine error and runs post-mortem assertions
+  against the partially-created resource BEFORE destroy, and a deploy that
+  unexpectedly SUCCEEDS fails the phase (with the cleanup destroy).
+- **`planton.dev/e2e-expected-runtime-failure: <cause>`** for substrates
+  that accept the deploy and fail asynchronously (ECS tasks, Container Apps
+  replicas, Kubernetes pods). The standard lifecycle gains a VERIFY-CAUSE
+  phase after VERIFY-RES.
+
+The evidence bar is CAUSE-PINNING with the provider's own APIs -- "everything
+worked except exactly the thing the scenario sabotaged", never a bare
+tolerance of any failure. The runner appliance's lanes are the worked
+example on all four substrates, and their first runs justified the bar
+loudly: the arm caught a reserved `PORT` env rejected by Cloud Run, a
+Cloud-Run `command` field silently REPLACING the image entrypoint
+("Application exec likely failed" with zero container logs), an image
+entrypoint that baked the subcommand and broke every consumer's argv, and a
+Fargate fixture topology with no egress (ResourceInitializationError before
+the container ever starts) -- every one invisible to provisioning-level
+verification. Two authoring rules earned there: an expected-deploy-failure
+harness implementation must STORE the manifest-derived identity after its
+post-mortem (VERIFY-CLN has no VerifyDeployed state to reuse), and
+runtime-cause classifiers should fail IMMEDIATELY on recognizable
+wrong-cause states (pull failures) rather than polling them into a timeout.
+
+### A kind node caches `:latest` -- a re-pushed tag needs the cache cleared
+
+The local kind cluster persists across suite runs and its containerd keeps
+pulled images. When a lane's image rides a MOVING tag (the runner's
+`:latest`) and the tag is re-pushed mid-session, the next lane silently
+runs the STALE cached image (recognize it by a suspiciously fast DEPLOY);
+`docker exec <kind-node> crictl rmi <image:tag>` clears it, and the re-run
+pulls fresh. Real clouds resolve tags at create and are not exposed.
+
 ### Bare polymorphic references need an explicit `kind:` in scenario valueFrom
 
 Reference resolution determines the referenced kind from the `valueFrom.kind`

--- a/e2e/framework/provider/BUILD.bazel
+++ b/e2e/framework/provider/BUILD.bazel
@@ -2,7 +2,10 @@ load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "provider",
-    srcs = ["provider.go"],
+    srcs = [
+        "failuremode.go",
+        "provider.go",
+    ],
     importpath = "github.com/plantonhq/planton/e2e/framework/provider",
     visibility = ["//visibility:public"],
 )

--- a/e2e/framework/provider/failuremode.go
+++ b/e2e/framework/provider/failuremode.go
@@ -1,0 +1,37 @@
+// Failure-mode verification capabilities -- optional Harness extensions the
+// runner discovers by type assertion. They exist for scenarios whose PROOF is a
+// deliberate, precisely-attributed failure: a component deployed with a
+// credential that a real service rejects (the canonical case: a Planton runner
+// appliance with a fake enrollment token). The evidence bar is cause-pinning
+// with the provider's own APIs -- "everything worked except exactly the thing
+// the scenario sabotaged" -- never a bare acceptance of any failure.
+
+package provider
+
+import "context"
+
+// RuntimeCauseVerifier verifies, AFTER a successful deploy, that a workload's
+// designed runtime failure has exactly the expected cause. Activated by the
+// scenario annotation `planton.dev/e2e-expected-runtime-failure`; the
+// annotation's value is passed as cause (e.g. "refused-join") so a harness can
+// support several causes over time. Runs between VERIFY-RES and DESTROY, so
+// stack outputs are available on tc. Implementations own their polling: runtime
+// failures take time to surface (a crash-looping container needs a restart or
+// two before its state and logs attest the cause).
+type RuntimeCauseVerifier interface {
+	VerifyRuntimeFailureCause(ctx context.Context, tc *ComponentTestContext, cause string) error
+}
+
+// DeployFailureVerifier verifies that a deploy which FAILED failed for exactly
+// the expected reason, on substrates that gate resource creation on workload
+// health (e.g. Cloud Run v2 gates service creation on first-revision
+// readiness). Activated by the scenario annotation
+// `planton.dev/e2e-expect-deploy-failure`; the annotation's value is passed as
+// expectation. deployErr carries the engine's full error output for
+// classification. Stack outputs do NOT exist when this runs -- implementations
+// derive identity from the manifest (via ManifestPathKey on ctx or
+// tc.ManifestPath) and must verify the partially-created resource's state with
+// the provider's own APIs BEFORE the runner destroys it.
+type DeployFailureVerifier interface {
+	VerifyExpectedDeployFailure(ctx context.Context, tc *ComponentTestContext, expectation string, deployErr error) error
+}

--- a/e2e/framework/runner/BUILD.bazel
+++ b/e2e/framework/runner/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "runner",
     srcs = [
         "dependencies.go",
+        "failuremode.go",
         "fixtureintegrity.go",
         "import_roundtrip.go",
         "outputs_verifier.go",
@@ -52,6 +53,7 @@ go_test(
     name = "runner_test",
     srcs = [
         "dependencies_test.go",
+        "failuremode_test.go",
         "fixture_integrity_test.go",
         "import_roundtrip_test.go",
         "outputs_verifier_test.go",
@@ -72,6 +74,7 @@ go_test(
         "//e2e/framework/provider",
         "//internal/manifest",
         "//shared/cloudresourcekind",
+        "@com_github_pkg_errors//:errors",
         "@io_k8s_sigs_yaml//:yaml",
     ],
 )

--- a/e2e/framework/runner/failuremode.go
+++ b/e2e/framework/runner/failuremode.go
@@ -1,0 +1,74 @@
+// Failure-mode lanes: scenarios whose PROOF is a deliberate, precisely
+// attributed failure. Two shapes, activated per scenario by manifest
+// annotation, both dispatching to optional harness capabilities (see the
+// provider package's failuremode.go):
+//
+//   - expected-deploy-failure, for substrates that gate resource creation on
+//     workload health (Cloud Run gates service creation on first-revision
+//     readiness): DEPLOY must FAIL, and the harness then proves it failed for
+//     exactly the expected reason -- with the partially-created resource's
+//     state and the workload's own logs -- before the stack is destroyed.
+//   - expected-runtime-failure, for substrates that accept the deploy and fail
+//     asynchronously (ECS tasks, Container Apps replicas, Kubernetes pods):
+//     the standard lifecycle runs, plus a VERIFY-CAUSE phase after VERIFY-RES
+//     asserting the workload's failure has exactly the expected cause (e.g. a
+//     refused control-plane join, never an image pull failure).
+//
+// The evidence bar is cause-pinning with the provider's own APIs. A lane that
+// merely tolerates "some failure" proves nothing; these lanes prove
+// "everything worked except exactly the thing the scenario sabotaged".
+
+package runner
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/plantonhq/planton/e2e/framework/provider"
+)
+
+const (
+	// ExpectDeployFailureAnnotation marks a scenario whose DEPLOY must fail.
+	// The value names the expected failure class (passed to the harness's
+	// DeployFailureVerifier), e.g. "revision-readiness".
+	ExpectDeployFailureAnnotation = "planton.dev/e2e-expect-deploy-failure"
+
+	// ExpectedRuntimeFailureAnnotation marks a scenario whose deploy succeeds
+	// while its workload fails by design. The value names the expected cause
+	// (passed to the harness's RuntimeCauseVerifier), e.g. "refused-join".
+	ExpectedRuntimeFailureAnnotation = "planton.dev/e2e-expected-runtime-failure"
+)
+
+// runExpectDeployFailure runs DEPLOY expecting it to FAIL, then hands the
+// engine's error to the harness for cause classification and post-mortem
+// state assertions. A deploy that SUCCEEDS fails the phase loudly: either the
+// sabotaged input no longer fails on this substrate (the scenario needs
+// updating) or the substrate stopped gating on workload health (a real
+// contract change worth catching). Either way the created resources are
+// destroyed by the pipeline's failure-cleanup path.
+func runExpectDeployFailure(ctx context.Context, tc *provider.ComponentTestContext, harness provider.Harness, expectation string) error {
+	fv, ok := harness.(provider.DeployFailureVerifier)
+	if !ok {
+		return errors.Errorf("scenario expects a deploy failure (%s) but the %s harness does not implement provider.DeployFailureVerifier",
+			expectation, tc.Provider)
+	}
+
+	deployErr := runDeploy(tc)
+	if deployErr == nil {
+		return errors.Errorf("the scenario expects the deploy to fail (%s), but it succeeded", expectation)
+	}
+	return errors.Wrap(fv.VerifyExpectedDeployFailure(ctx, tc, expectation, deployErr),
+		"deploy failed as expected, but the failure could not be attributed to the expected cause")
+}
+
+// runVerifyRuntimeCause asserts a deployed-but-designed-to-fail workload's
+// failure has exactly the expected cause, via the harness's optional
+// RuntimeCauseVerifier capability.
+func runVerifyRuntimeCause(ctx context.Context, tc *provider.ComponentTestContext, harness provider.Harness, cause string) error {
+	rv, ok := harness.(provider.RuntimeCauseVerifier)
+	if !ok {
+		return errors.Errorf("scenario expects a runtime failure cause (%s) but the %s harness does not implement provider.RuntimeCauseVerifier",
+			cause, tc.Provider)
+	}
+	return rv.VerifyRuntimeFailureCause(ctx, tc, cause)
+}

--- a/e2e/framework/runner/failuremode_test.go
+++ b/e2e/framework/runner/failuremode_test.go
@@ -1,0 +1,114 @@
+package runner
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/plantonhq/planton/e2e/framework/provider"
+)
+
+// bareHarness implements ONLY the base Harness interface -- the common case
+// against which the failure-mode capabilities must fail loudly, never
+// silently pass.
+type bareHarness struct{}
+
+func (bareHarness) Setup(context.Context) error    { return nil }
+func (bareHarness) Teardown(context.Context) error { return nil }
+func (bareHarness) VerifyDeployed(context.Context, string, map[string]interface{}) error {
+	return nil
+}
+func (bareHarness) VerifyDestroyed(context.Context, string) error { return nil }
+
+// causeHarness adds the RuntimeCauseVerifier capability and records the call.
+type causeHarness struct {
+	bareHarness
+	gotCause string
+	fail     bool
+}
+
+func (h *causeHarness) VerifyRuntimeFailureCause(_ context.Context, _ *provider.ComponentTestContext, cause string) error {
+	h.gotCause = cause
+	if h.fail {
+		return errors.New("cause mismatch")
+	}
+	return nil
+}
+
+func TestRunVerifyRuntimeCause(t *testing.T) {
+	tc := &provider.ComponentTestContext{Component: "x", Provider: "azure"}
+
+	// A harness without the capability must fail loudly, naming the gap.
+	err := runVerifyRuntimeCause(context.Background(), tc, bareHarness{}, "refused-join")
+	if err == nil || !strings.Contains(err.Error(), "RuntimeCauseVerifier") {
+		t.Fatalf("expected a capability-missing error, got %v", err)
+	}
+
+	// A harness with the capability receives the annotation's cause value.
+	h := &causeHarness{}
+	if err := runVerifyRuntimeCause(context.Background(), tc, h, "refused-join"); err != nil {
+		t.Fatalf("expected pass-through success, got %v", err)
+	}
+	if h.gotCause != "refused-join" {
+		t.Fatalf("cause = %q, want refused-join", h.gotCause)
+	}
+
+	// A failing cause verification propagates.
+	h.fail = true
+	if err := runVerifyRuntimeCause(context.Background(), tc, h, "refused-join"); err == nil {
+		t.Fatal("expected the cause-verification failure to propagate")
+	}
+}
+
+func TestRunExpectDeployFailure_CapabilityGate(t *testing.T) {
+	// The capability check fires BEFORE any deploy is attempted, so a
+	// mis-wired scenario fails in milliseconds, not after a cloud apply.
+	tc := &provider.ComponentTestContext{Component: "x", Provider: "gcp"}
+	err := runExpectDeployFailure(context.Background(), tc, bareHarness{}, "revision-readiness")
+	if err == nil || !strings.Contains(err.Error(), "DeployFailureVerifier") {
+		t.Fatalf("expected a capability-missing error, got %v", err)
+	}
+}
+
+func TestFailureModeAnnotations_MutuallyExclusive(t *testing.T) {
+	dir := t.TempDir()
+	manifest := filepath.Join(dir, "both.yaml")
+	content := `apiVersion: azure.planton.dev/v1alpha1
+kind: AzurePlantonRunner
+metadata:
+  name: both-modes
+  annotations:
+    planton.dev/e2e-expect-deploy-failure: revision-readiness
+    planton.dev/e2e-expected-runtime-failure: refused-join
+spec: {}
+`
+	if err := os.WriteFile(manifest, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// RepoRoot empty skips dependency deployment, so the run reaches the
+	// annotation gate hermetically.
+	tc := &provider.ComponentTestContext{
+		Component:    "azureplantonrunner",
+		Provider:     "azure",
+		Engine:       "pulumi",
+		ManifestPath: manifest,
+		RunID:        "t1",
+	}
+	res := RunComponentTest(context.Background(), tc, bareHarness{})
+	if res.Passed {
+		t.Fatal("expected the run to fail on mutually exclusive annotations")
+	}
+	found := false
+	for _, p := range res.Phases {
+		if p.Error != nil && strings.Contains(p.Error.Error(), "mutually exclusive") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected the mutual-exclusion error in phases, got %+v", res.Phases)
+	}
+}

--- a/e2e/framework/runner/runner.go
+++ b/e2e/framework/runner/runner.go
@@ -27,6 +27,13 @@ const (
 	PhaseDestroy     Phase = "DESTROY"
 	PhaseVerifyCln   Phase = "VERIFY-CLN"
 	PhaseDepsDn      Phase = "DEPENDENCIES-DOWN"
+
+	// Failure-mode phases (see failuremode.go): DEPLOY-EXPECT-FAIL replaces
+	// DEPLOY when the scenario expects the deploy itself to fail;
+	// VERIFY-CAUSE follows VERIFY-RES when the scenario's workload fails by
+	// design and the failure's cause must be pinned.
+	PhaseExpectFail  Phase = "DEPLOY-EXPECT-FAIL"
+	PhaseVerifyCause Phase = "VERIFY-CAUSE"
 )
 
 // PhaseResult captures the outcome of a single lifecycle phase.
@@ -173,40 +180,83 @@ func RunComponentTest(ctx context.Context, tc *provider.ComponentTestContext, ha
 		}
 	}
 
+	// Failure-mode annotations (see failuremode.go). Mutually exclusive: one
+	// says the deploy itself must fail, the other presupposes it succeeds.
+	expectDeployFailure, _ := ManifestAnnotation(tc.ManifestPath, ExpectDeployFailureAnnotation)
+	expectedRuntimeCause, _ := ManifestAnnotation(tc.ManifestPath, ExpectedRuntimeFailureAnnotation)
+	if expectDeployFailure != "" && expectedRuntimeCause != "" {
+		result.Passed = false
+		result.Phases = append(result.Phases, PhaseResult{
+			Phase:  PhaseValidate,
+			Passed: false,
+			Error: errors.Errorf("scenario carries both %s and %s -- they are mutually exclusive",
+				ExpectDeployFailureAnnotation, ExpectedRuntimeFailureAnnotation),
+		})
+		if tdErr := TeardownDependencies(dependencyStates); tdErr != nil {
+			result.Phases = append(result.Phases, PhaseResult{Phase: PhaseDepsDn, Passed: false, Error: tdErr})
+		}
+		result.Duration = time.Since(start)
+		return result
+	}
+
 	// Phases 1-6 (7 with the opt-in import round-trip): standard lifecycle.
 	type lifecyclePhase struct {
 		phase Phase
 		fn    func() error
 	}
-	phases := []lifecyclePhase{
-		{PhaseValidate, func() error { return runValidate(tc) }},
-		{PhaseDeploy, func() error { return runDeploy(tc) }},
+	var phases []lifecyclePhase
+	if expectDeployFailure != "" {
+		// The expected-deploy-failure lifecycle: the deploy MUST fail, the
+		// harness pins the cause post-mortem (before destroy, while the
+		// partially-created resource is inspectable), then the tainted stack
+		// is destroyed and absence verified. Idempotency, output and resource
+		// verification, and import round-trips all presuppose a successful
+		// deploy and are structurally excluded.
+		phases = []lifecyclePhase{
+			{PhaseValidate, func() error { return runValidate(tc) }},
+			{PhaseExpectFail, func() error { return runExpectDeployFailure(verifyCtx, tc, harness, expectDeployFailure) }},
+			{PhaseDestroy, func() error { return runDestroy(tc) }},
+			{PhaseVerifyCln, func() error { return runVerifyCleanup(verifyCtx, tc, harness) }},
+		}
+	} else {
+		phases = []lifecyclePhase{
+			{PhaseValidate, func() error { return runValidate(tc) }},
+			{PhaseDeploy, func() error { return runDeploy(tc) }},
+		}
+		// The idempotency gate re-plans the configuration DEPLOY just applied and
+		// fails on any pending change: a dirty second plan means the module and
+		// the provider disagree about the applied state (the send-omitted-value /
+		// Optional+Computed echo defect classes), which users would meet as a
+		// perpetual diff on every re-apply. Provider profiles arm it via
+		// assert_apply_idempotency; prerequisite fixtures are deliberately outside
+		// its scope (they belong to other kinds' contracts).
+		if tc.AssertApplyIdempotency {
+			phases = append(phases, lifecyclePhase{PhaseIdempotency, func() error { return runIdempotency(tc) }})
+		}
+		phases = append(phases,
+			lifecyclePhase{PhaseVerifyOut, func() error { return runVerifyOutputs(tc) }},
+			lifecyclePhase{PhaseVerifyRes, func() error { return runVerifyResources(verifyCtx, tc, harness) }},
+		)
+		// VERIFY-CAUSE slots right after VERIFY-RES: the workload's designed
+		// failure needs the deployed resource live, and its evidence (states,
+		// logs) must be read before anything tears down.
+		if expectedRuntimeCause != "" {
+			phases = append(phases, lifecyclePhase{PhaseVerifyCause, func() error {
+				return runVerifyRuntimeCause(verifyCtx, tc, harness, expectedRuntimeCause)
+			}})
+		}
+		// The import round-trip slots between VERIFY-RES and DESTROY: it needs the
+		// deployed fixture live (imports read the real cloud) and the destroy that
+		// follows tears down through the re-imported state -- itself part of the
+		// proof that the blind import fully owns the resources.
+		if importRoundTripEnabled(tc) {
+			phases = append(phases, lifecyclePhase{PhaseImportRT, func() error { return runImportRoundTrip(tc) }})
+		}
+		phases = append(phases,
+			lifecyclePhase{PhaseDestroy, func() error { return runDestroy(tc) }},
+			lifecyclePhase{PhaseVerifyCln, func() error { return runVerifyCleanup(verifyCtx, tc, harness) }},
+		)
 	}
-	// The idempotency gate re-plans the configuration DEPLOY just applied and
-	// fails on any pending change: a dirty second plan means the module and
-	// the provider disagree about the applied state (the send-omitted-value /
-	// Optional+Computed echo defect classes), which users would meet as a
-	// perpetual diff on every re-apply. Provider profiles arm it via
-	// assert_apply_idempotency; prerequisite fixtures are deliberately outside
-	// its scope (they belong to other kinds' contracts).
-	if tc.AssertApplyIdempotency {
-		phases = append(phases, lifecyclePhase{PhaseIdempotency, func() error { return runIdempotency(tc) }})
-	}
-	phases = append(phases,
-		lifecyclePhase{PhaseVerifyOut, func() error { return runVerifyOutputs(tc) }},
-		lifecyclePhase{PhaseVerifyRes, func() error { return runVerifyResources(verifyCtx, tc, harness) }},
-	)
-	// The import round-trip slots between VERIFY-RES and DESTROY: it needs the
-	// deployed fixture live (imports read the real cloud) and the destroy that
-	// follows tears down through the re-imported state -- itself part of the
-	// proof that the blind import fully owns the resources.
-	if importRoundTripEnabled(tc) {
-		phases = append(phases, lifecyclePhase{PhaseImportRT, func() error { return runImportRoundTrip(tc) }})
-	}
-	phases = append(phases,
-		lifecyclePhase{PhaseDestroy, func() error { return runDestroy(tc) }},
-		lifecyclePhase{PhaseVerifyCln, func() error { return runVerifyCleanup(verifyCtx, tc, harness) }},
-	)
 
 	for _, p := range phases {
 		phaseStart := time.Now()
@@ -221,7 +271,11 @@ func RunComponentTest(ctx context.Context, tc *provider.ComponentTestContext, ha
 
 		if err != nil {
 			result.Passed = false
-			if p.phase == PhaseDeploy || p.phase == PhaseIdempotency || p.phase == PhaseVerifyOut || p.phase == PhaseVerifyRes || p.phase == PhaseImportRT {
+			switch p.phase {
+			case PhaseDeploy, PhaseIdempotency, PhaseVerifyOut, PhaseVerifyRes, PhaseVerifyCause, PhaseImportRT, PhaseExpectFail:
+				// A failed DEPLOY-EXPECT-FAIL needs the cleanup destroy on BOTH
+				// branches: an unexpected deploy success leaves live resources,
+				// and a failed post-mortem leaves the tainted partial stack.
 				cleanupErr := runDestroy(tc)
 				if cleanupErr != nil {
 					fmt.Printf("  [WARN] cleanup destroy also failed: %v\n", cleanupErr)

--- a/e2e/gcp/gcp_test.go
+++ b/e2e/gcp/gcp_test.go
@@ -23,6 +23,8 @@ import (
 	gcpe2e "github.com/plantonhq/planton/catalog/gcp/aa_e2e"
 	"github.com/plantonhq/planton/e2e/framework/discovery"
 	"github.com/plantonhq/planton/e2e/framework/provider"
+	"strings"
+
 	"github.com/plantonhq/planton/e2e/framework/runner"
 	"github.com/plantonhq/planton/pkg/e2e/profile"
 	componentv1 "github.com/plantonhq/planton/qa/componente2eprofile/v1"
@@ -1014,6 +1016,18 @@ func runAllScenariosForComponent(t *testing.T, component, engine string) {
 
 func runSingleScenario(t *testing.T, component, moduleDir, engine string, scenario discovery.TestScenario) {
 	t.Helper()
+
+	// Scenarios needing owner-arranged external credentials (the
+	// e2e-required-env annotation) skip honestly where the environment
+	// does not carry the arrangement — unset ${E2E_ENV:...} tokens would
+	// otherwise fail expansion loudly, turning a deferral into a false
+	// failure on every lane without the tokens (CI included).
+	if missing, err := runner.ScenarioMissingRequiredEnv(scenario.ManifestPath); err != nil {
+		t.Fatalf("reading required-env declaration for scenario %s/%s: %v", component, scenario.Name, err)
+	} else if len(missing) > 0 {
+		t.Skipf("scenario %s/%s needs owner-arranged environment variables that are unset: %s (per %s)",
+			component, scenario.Name, strings.Join(missing, ", "), runner.ScenarioRequiredEnvAnnotation)
+	}
 
 	tc := &provider.ComponentTestContext{
 		Component:    component,


### PR DESCRIPTION
## Summary

- The E2E framework gains **failure-mode lanes** — a deliberate failure becomes machine-verified evidence. Two annotation-activated shapes with per-kind cause verifiers: `planton.dev/e2e-expect-deploy-failure` (substrates gating creation on workload health: Cloud Run — lifecycle becomes VALIDATE → DEPLOY-EXPECT-FAIL → DESTROY → VERIFY-CLN with post-mortem assertions against the partially-created resource) and `planton.dev/e2e-expected-runtime-failure` (async substrates gain a VERIFY-CAUSE phase). The evidence bar is cause-pinning with each provider's own APIs: pod status + logs (Kubernetes), stopped-task history + CloudWatch (ECS), ARM revision state (Container Apps), deploy-error classification + service template + Cloud Logging (Cloud Run). Hermetically unit-tested; documented in `e2e/README.md`.
- First contact caught and fixed **three adopter-blocking runner-module defects**: the GCP modules set the reserved `PORT` env (Cloud Run 400s the create) and used `command` for the subcommand (Cloud Run's `command` REPLACES the image entrypoint — "Application exec likely failed" with zero container logs; now `args`), and the AWS scenario's bare fixture subnets gave Fargate zero egress (`ResourceInitializationError` before the container ever starts; now consumer-scoped internet-routed subnets + `assignPublicIp`).
- **Proofs, all live on both engines**: `kubernetesplantonrunner` GREEN (first proof); `awsplantonrunner` + `azureplantonrunner` re-proven at the strengthened cause-pinned bar; `gcpplantonrunner` failure-mode proven via the new secret-free `fake-token-failure-mode` scenario (profile honestly `pending_proof` until one owner-arranged real-token run proves ready-state). Zero orphans on all three clouds.

## Test plan

- [x] `go test ./e2e/framework/runner/` (failure-mode unit tests + fixture-integrity gate)
- [x] Live lanes, both engines each: Kubernetes (kind), GCP failure-mode, Azure, AWS — phase logs in the session record
- [x] `go build` all touched harness/verify/module packages; gofmt; gazelle
- [x] Orphan sweeps: Azure 0 groups, AWS 0 e2e VPCs/clusters/secrets, GCP 0 services/secrets