### PR TITLE
fix(catalog/aws): a pipe or a schedule that launches a task into a subnet never lives in it on a diagram; the EventBridge pipe's and schedule's task subnets are access, not placement

### DIFF
--- a/_changelog/2026-09/2026-09-07-200000-a-pipe-or-a-schedule-that-launches-a-task-into-a-subnet-never-lives-in-it-on-a-diagram.md
+++ b/_changelog/2026-09/2026-09-07-200000-a-pipe-or-a-schedule-that-launches-a-task-into-a-subnet-never-lives-in-it-on-a-diagram.md
@@ -1,0 +1,19 @@
+# A pipe or a schedule that launches a task into a subnet never lives in it on a diagram
+
+## What changed
+
+- **`AwsEventBridgePipeEcsNetworkConfiguration.subnets` is containment-exempt.** A pipe whose target is an ECS task names the subnets that task launches into. Those subnets place the task, not the pipe -- the pipe is a managed service outside the network. Until now the reference was placement by omission, so a pipe with an ECS target was drawn inside the VPC (or one subnet) it only launched tasks into.
+- **`AwsEventBridgePipeSelfManagedKafkaVpc.subnets` is containment-exempt.** A pipe reading from self-managed Kafka names the subnets its client reaches the brokers through. The pipe reaches INTO the VPC to poll; it is not deployed there -- the verdict a Lambda function's VPC subnets already carry.
+- **`AwsEventBridgeScheduleNetworkConfiguration.subnets` is containment-exempt.** The same verdict for a schedule whose target is an ECS task.
+- The containment-decision registry (`shared/cloudresourcekind/testdata/containment_decisions.txt`) moves exactly those three lines from `contained` to `exempt`; nothing else in the registry moved.
+
+## Why
+
+`container_kind` says a kind is a box other resources nest inside, and `containment_exempt` says a reference into such a box is access, not placement. The EventBridge rule's ECS target subnets (`AwsEventBridgeEcsNetworkConfiguration.subnets`) already carry the exemption for exactly this reason; the pipe's and the schedule's identical fields did not, so the same configuration drew three different pictures depending on which EventBridge kind launched the task. On a diagram all three now stand beside the network with a line in, and only the resources that live in a subnet are drawn inside it.
+
+## How to check
+
+```bash
+go test ./shared/cloudresourcekind/... -run TestContainmentDecisions   # green; the golden carries the three exempt lines
+grep -n containment_exempt catalog/aws/awseventbridgepipe/v1alpha1/spec.proto catalog/aws/awseventbridgescheduler/v1alpha1/spec.proto
+```

--- a/catalog/aws/awseventbridgepipe/v1alpha1/spec.pb.go
+++ b/catalog/aws/awseventbridgepipe/v1alpha1/spec.pb.go
@@ -1071,6 +1071,11 @@ type AwsEventBridgePipeSelfManagedKafkaVpc struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The subnets the client uses (at most 16). Reference AwsSubnet
 	// subnet_id outputs or pass literal subnet-... ids.
+	//
+	// Containment-exempt: the pipe is a managed service that reaches INTO
+	// the VPC to poll the brokers; it is not deployed into the subnets. On a
+	// diagram the pipe stands outside the network with a line in -- the same
+	// verdict a Lambda function's VPC subnets carry.
 	Subnets []*v1.StringValueOrRef `protobuf:"bytes,1,rep,name=subnets,proto3" json:"subnets,omitempty"`
 	// The security groups attached to the client (at most 5). Reference
 	// AwsSecurityGroup security_group_id outputs or pass literal sg-...
@@ -2013,6 +2018,11 @@ type AwsEventBridgePipeEcsNetworkConfiguration struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The subnets tasks launch into (at most 16). Reference AwsSubnet
 	// subnet_id outputs or pass literal subnet-... ids.
+	//
+	// Containment-exempt: these subnets place the ECS TASKS the pipe
+	// launches, not the pipe itself, which is a managed service outside the
+	// network. On a diagram the pipe stands beside the VPC with a line in --
+	// the verdict an EventBridge rule's ECS target subnets already carry.
 	Subnets []*v1.StringValueOrRef `protobuf:"bytes,1,rep,name=subnets,proto3" json:"subnets,omitempty"`
 	// The security groups attached to tasks (at most 5). Unset uses the
 	// VPC's default. Reference AwsSecurityGroup security_group_id
@@ -3640,9 +3650,9 @@ const file_catalog_aws_awseventbridgepipe_v1alpha1_spec_proto_rawDesc = "" +
 	"\x1bclient_certificate_tls_auth\x18\x02 \x01(\tB'\xbaH$\xd8\x01\x01r\x1f2\x1d^arn:aws.*:secretsmanager:.*$R\x18clientCertificateTlsAuth\x12V\n" +
 	"\x13sasl_scram_256_auth\x18\x03 \x01(\tB'\xbaH$\xd8\x01\x01r\x1f2\x1d^arn:aws.*:secretsmanager:.*$R\x10saslScram256Auth\x12V\n" +
 	"\x13sasl_scram_512_auth\x18\x04 \x01(\tB'\xbaH$\xd8\x01\x01r\x1f2\x1d^arn:aws.*:secretsmanager:.*$R\x10saslScram512Auth:\xa9\x02\xbaH\xa5\x02\x1a\xa2\x02\n" +
-	"\x1bsmk_credentials.exactly_one\x12hset exactly one of basic_auth, client_certificate_tls_auth, sasl_scram_256_auth, and sasl_scram_512_auth\x1a\x98\x01[this.basic_auth != '', this.client_certificate_tls_auth != '', this.sasl_scram_256_auth != '', this.sasl_scram_512_auth != ''].filter(x, x).size() == 1\"\xb3\x02\n" +
-	"%AwsEventBridgePipeSelfManagedKafkaVpc\x12y\n" +
-	"\asubnets\x18\x01 \x03(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB+\xbaH\a\x92\x01\x04\b\x01\x10\x10\x88\xd4a\xbc\b\x92\xd4a\x18status.outputs.subnet_idR\asubnets\x12\x8e\x01\n" +
+	"\x1bsmk_credentials.exactly_one\x12hset exactly one of basic_auth, client_certificate_tls_auth, sasl_scram_256_auth, and sasl_scram_512_auth\x1a\x98\x01[this.basic_auth != '', this.client_certificate_tls_auth != '', this.sasl_scram_256_auth != '', this.sasl_scram_512_auth != ''].filter(x, x).size() == 1\"\xb7\x02\n" +
+	"%AwsEventBridgePipeSelfManagedKafkaVpc\x12}\n" +
+	"\asubnets\x18\x01 \x03(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB/\xbaH\a\x92\x01\x04\b\x01\x10\x10\x88\xd4a\xbc\b\x92\xd4a\x18status.outputs.subnet_id\x98\xd4a\x01R\asubnets\x12\x8e\x01\n" +
 	"\x0fsecurity_groups\x18\x02 \x03(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB1\xbaH\x05\x92\x01\x02\x10\x05\x88\xd4a\xf7\a\x92\xd4a status.outputs.security_group_idR\x0esecurityGroups\"\xc1\x03\n" +
 	"*AwsEventBridgePipeActiveMqSourceParameters\x12)\n" +
 	"\n" +
@@ -3738,9 +3748,9 @@ const file_catalog_aws_awseventbridgepipe_v1alpha1_spec_proto_rawDesc = "" +
 	"\xbaH\ar\x05\x10\x01\x18\xff\x01R\x10capacityProvider\x12\x1f\n" +
 	"\x04base\x18\x02 \x01(\x05B\v\xbaH\b\x1a\x06\x18\xa0\x8d\x06(\x00R\x04base\x12\"\n" +
 	"\x06weight\x18\x03 \x01(\x05B\n" +
-	"\xbaH\a\x1a\x05\x18\xe8\a(\x00R\x06weight\"\xe1\x02\n" +
-	")AwsEventBridgePipeEcsNetworkConfiguration\x12y\n" +
-	"\asubnets\x18\x01 \x03(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB+\xbaH\a\x92\x01\x04\b\x01\x10\x10\x88\xd4a\xbc\b\x92\xd4a\x18status.outputs.subnet_idR\asubnets\x12\x8e\x01\n" +
+	"\xbaH\a\x1a\x05\x18\xe8\a(\x00R\x06weight\"\xe5\x02\n" +
+	")AwsEventBridgePipeEcsNetworkConfiguration\x12}\n" +
+	"\asubnets\x18\x01 \x03(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB/\xbaH\a\x92\x01\x04\b\x01\x10\x10\x88\xd4a\xbc\b\x92\xd4a\x18status.outputs.subnet_id\x98\xd4a\x01R\asubnets\x12\x8e\x01\n" +
 	"\x0fsecurity_groups\x18\x02 \x03(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB1\xbaH\x05\x92\x01\x02\x10\x05\x88\xd4a\xf7\a\x92\xd4a status.outputs.security_group_idR\x0esecurityGroups\x12(\n" +
 	"\x10assign_public_ip\x18\x03 \x01(\bR\x0eassignPublicIp\"\x82\x06\n" +
 	"\"AwsEventBridgePipeEcsTaskOverrides\x12\x84\x01\n" +

--- a/catalog/aws/awseventbridgepipe/v1alpha1/spec.proto
+++ b/catalog/aws/awseventbridgepipe/v1alpha1/spec.proto
@@ -504,13 +504,19 @@ message AwsEventBridgePipeSelfManagedKafkaCredentials {
 message AwsEventBridgePipeSelfManagedKafkaVpc {
   // The subnets the client uses (at most 16). Reference AwsSubnet
   // subnet_id outputs or pass literal subnet-... ids.
+  //
+  // Containment-exempt: the pipe is a managed service that reaches INTO
+  // the VPC to poll the brokers; it is not deployed into the subnets. On a
+  // diagram the pipe stands outside the network with a line in -- the same
+  // verdict a Lambda function's VPC subnets carry.
   repeated dev.planton.shared.foreignkey.v1.StringValueOrRef subnets = 1 [
     (buf.validate.field).repeated = {
       min_items: 1
       max_items: 16
     },
     (dev.planton.shared.foreignkey.v1.default_kind) = AwsSubnet,
-    (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.subnet_id"
+    (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.subnet_id",
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true
   ];
 
   // The security groups attached to the client (at most 5). Reference
@@ -844,13 +850,19 @@ message AwsEventBridgePipeCapacityProviderStrategy {
 message AwsEventBridgePipeEcsNetworkConfiguration {
   // The subnets tasks launch into (at most 16). Reference AwsSubnet
   // subnet_id outputs or pass literal subnet-... ids.
+  //
+  // Containment-exempt: these subnets place the ECS TASKS the pipe
+  // launches, not the pipe itself, which is a managed service outside the
+  // network. On a diagram the pipe stands beside the VPC with a line in --
+  // the verdict an EventBridge rule's ECS target subnets already carry.
   repeated dev.planton.shared.foreignkey.v1.StringValueOrRef subnets = 1 [
     (buf.validate.field).repeated = {
       min_items: 1
       max_items: 16
     },
     (dev.planton.shared.foreignkey.v1.default_kind) = AwsSubnet,
-    (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.subnet_id"
+    (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.subnet_id",
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true
   ];
 
   // The security groups attached to tasks (at most 5). Unset uses the

--- a/catalog/aws/awseventbridgescheduler/v1alpha1/spec.pb.go
+++ b/catalog/aws/awseventbridgescheduler/v1alpha1/spec.pb.go
@@ -763,6 +763,12 @@ type AwsEventBridgeScheduleNetworkConfiguration struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The subnets tasks launch into. Reference AwsSubnet subnet_id
 	// outputs or pass literal subnet-... ids.
+	//
+	// Containment-exempt: these subnets place the ECS TASKS the schedule
+	// launches, not the schedule itself, which is a managed service outside
+	// the network. On a diagram the schedule stands beside the VPC with a
+	// line in -- the verdict an EventBridge rule's ECS target subnets
+	// already carry.
 	Subnets []*v1.StringValueOrRef `protobuf:"bytes,1,rep,name=subnets,proto3" json:"subnets,omitempty"`
 	// The security groups attached to tasks. Unset uses the VPC's
 	// default. Reference AwsSecurityGroup security_group_id outputs or
@@ -1278,9 +1284,9 @@ const file_catalog_aws_awseventbridgescheduler_v1alpha1_spec_proto_rawDesc = "" 
 	"\xbaH\ar\x05\x10\x01\x18\xff\x01R\x10capacityProvider\x12\x1f\n" +
 	"\x04base\x18\x02 \x01(\x05B\v\xbaH\b\x1a\x06\x18\xa0\x8d\x06(\x00R\x04base\x12\"\n" +
 	"\x06weight\x18\x03 \x01(\x05B\n" +
-	"\xbaH\a\x1a\x05\x18\xe8\a(\x00R\x06weight\"\xd8\x02\n" +
-	"*AwsEventBridgeScheduleNetworkConfiguration\x12w\n" +
-	"\asubnets\x18\x01 \x03(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB)\xbaH\x05\x92\x01\x02\b\x01\x88\xd4a\xbc\b\x92\xd4a\x18status.outputs.subnet_idR\asubnets\x12\x86\x01\n" +
+	"\xbaH\a\x1a\x05\x18\xe8\a(\x00R\x06weight\"\xdc\x02\n" +
+	"*AwsEventBridgeScheduleNetworkConfiguration\x12{\n" +
+	"\asubnets\x18\x01 \x03(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB-\xbaH\x05\x92\x01\x02\b\x01\x88\xd4a\xbc\b\x92\xd4a\x18status.outputs.subnet_id\x98\xd4a\x01R\asubnets\x12\x86\x01\n" +
 	"\x0fsecurity_groups\x18\x02 \x03(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB)\x88\xd4a\xf7\a\x92\xd4a status.outputs.security_group_idR\x0esecurityGroups\x12(\n" +
 	"\x10assign_public_ip\x18\x03 \x01(\bR\x0eassignPublicIp\"\x8f\x01\n" +
 	")AwsEventBridgeSchedulePlacementConstraint\x125\n" +

--- a/catalog/aws/awseventbridgescheduler/v1alpha1/spec.proto
+++ b/catalog/aws/awseventbridgescheduler/v1alpha1/spec.proto
@@ -347,10 +347,17 @@ message AwsEventBridgeScheduleCapacityProviderStrategy {
 message AwsEventBridgeScheduleNetworkConfiguration {
   // The subnets tasks launch into. Reference AwsSubnet subnet_id
   // outputs or pass literal subnet-... ids.
+  //
+  // Containment-exempt: these subnets place the ECS TASKS the schedule
+  // launches, not the schedule itself, which is a managed service outside
+  // the network. On a diagram the schedule stands beside the VPC with a
+  // line in -- the verdict an EventBridge rule's ECS target subnets
+  // already carry.
   repeated dev.planton.shared.foreignkey.v1.StringValueOrRef subnets = 1 [
     (buf.validate.field).repeated.min_items = 1,
     (dev.planton.shared.foreignkey.v1.default_kind) = AwsSubnet,
-    (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.subnet_id"
+    (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.subnet_id",
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true
   ];
 
   // The security groups attached to tasks. Unset uses the VPC's

--- a/shared/cloudresourcekind/testdata/containment_decisions.txt
+++ b/shared/cloudresourcekind/testdata/containment_decisions.txt
@@ -47,10 +47,7 @@ contained dev.planton.aws.awseksfargateprofile.v1alpha1.AwsEksFargateProfileSpec
 contained dev.planton.aws.awseksnodegroup.v1alpha1.AwsEksNodeGroupSpec.cluster_name -> AwsEksCluster
 contained dev.planton.aws.awseksnodegroup.v1alpha1.AwsEksNodeGroupSpec.subnet_ids -> AwsSubnet
 contained dev.planton.aws.awselasticfilesystem.v1alpha1.AwsElasticFileSystemMountTarget.subnet_id -> AwsSubnet
-contained dev.planton.aws.awseventbridgepipe.v1alpha1.AwsEventBridgePipeEcsNetworkConfiguration.subnets -> AwsSubnet
-contained dev.planton.aws.awseventbridgepipe.v1alpha1.AwsEventBridgePipeSelfManagedKafkaVpc.subnets -> AwsSubnet
 contained dev.planton.aws.awseventbridgerule.v1alpha1.AwsEventBridgeRuleSpec.event_bus_name -> AwsEventBridgeBus
-contained dev.planton.aws.awseventbridgescheduler.v1alpha1.AwsEventBridgeScheduleNetworkConfiguration.subnets -> AwsSubnet
 contained dev.planton.aws.awsfsxdatarepositoryassociation.v1alpha1.AwsFsxDataRepositoryAssociationSpec.file_system_id -> AwsFsxLustreFileSystem
 contained dev.planton.aws.awsfsxlustrefilesystem.v1alpha1.AwsFsxLustreFileSystemSpec.subnet_id -> AwsSubnet
 contained dev.planton.aws.awsfsxontapfilesystem.v1alpha1.AwsFsxOntapFileSystemSpec.preferred_subnet_id -> AwsSubnet
@@ -664,7 +661,10 @@ exempt    dev.planton.aws.awsecscluster.v1alpha1.AwsEcsClusterManagedInstancesNe
 exempt    dev.planton.aws.awsecsservice.v1alpha1.AwsEcsServiceNetwork.subnets -> AwsSubnet
 exempt    dev.planton.aws.awsecstaskdefinition.v1alpha1.AwsEcsTaskDefinitionEfsVolume.file_system_id -> AwsElasticFileSystem
 exempt    dev.planton.aws.awselasticfilesystem.v1alpha1.AwsElasticFileSystemReplication.destination_file_system_id -> AwsElasticFileSystem
+exempt    dev.planton.aws.awseventbridgepipe.v1alpha1.AwsEventBridgePipeEcsNetworkConfiguration.subnets -> AwsSubnet
+exempt    dev.planton.aws.awseventbridgepipe.v1alpha1.AwsEventBridgePipeSelfManagedKafkaVpc.subnets -> AwsSubnet
 exempt    dev.planton.aws.awseventbridgerule.v1alpha1.AwsEventBridgeEcsNetworkConfiguration.subnets -> AwsSubnet
+exempt    dev.planton.aws.awseventbridgescheduler.v1alpha1.AwsEventBridgeScheduleNetworkConfiguration.subnets -> AwsSubnet
 exempt    dev.planton.aws.awsfsxontapfilesystem.v1alpha1.AwsFsxOntapFileSystemSpec.route_table_ids -> AwsSubnet
 exempt    dev.planton.aws.awsfsxopenzfsfilesystem.v1alpha1.AwsFsxOpenzfsFileSystemSpec.route_table_ids -> AwsSubnet
 exempt    dev.planton.aws.awshttpapigateway.v1alpha1.AwsHttpApiGatewayJwtConfig.issuer -> AwsCognitoUserPool


### PR DESCRIPTION
## What

Three EventBridge subnet references become `containment_exempt`:

- `AwsEventBridgePipeEcsNetworkConfiguration.subnets` -- the subnets an ECS-target pipe launches its tasks into
- `AwsEventBridgePipeSelfManagedKafkaVpc.subnets` -- the subnets a Kafka-source pipe's client reaches the brokers through
- `AwsEventBridgeScheduleNetworkConfiguration.subnets` -- the subnets an ECS-target schedule launches its tasks into

Each field's comment states the verdict and its precedent. Go stubs regenerated with the pinned `protoc-gen-go v1.36.6`. The containment-decision registry moves exactly these three lines from `contained` to `exempt`; nothing else moved.

## Why

A pipe and a schedule are managed services outside the network. These subnets place the ECS **tasks** they launch (or the Kafka client's network path), not the pipe or the schedule. The EventBridge rule's identical ECS target field (`AwsEventBridgeEcsNetworkConfiguration.subnets`) already carries the exemption, and a Lambda function's VPC subnets carry it for the same reason -- so the same configuration drew three different pictures depending on which EventBridge kind launched the task. On a diagram all three now stand beside the VPC with a line in; only resources that live in a subnet are drawn inside it.

## Test plan

- [x] `buf lint` and `buf format -d` clean on both packages
- [x] `go test ./shared/cloudresourcekind/...` green with exactly three golden lines moved
- [x] Changelog entry under `_changelog/2026-09/`