### PR TITLE
fix(catalog/aws): a Studio space that mounts a file system never lives in it on a diagram; the SageMaker domain's space-level EFS reference is access, not placement

### DIFF
--- a/_changelog/2026-09/2026-09-07-224500-a-studio-space-that-mounts-a-file-system-never-lives-in-it-on-a-diagram.md
+++ b/_changelog/2026-09/2026-09-07-224500-a-studio-space-that-mounts-a-file-system-never-lives-in-it-on-a-diagram.md
@@ -1,0 +1,17 @@
+# A Studio space that mounts a file system never lives in it on a diagram
+
+## What changed
+
+- **`AwsSagemakerDomainSpaceCustomFileSystem.file_system_id` is containment-exempt.** A SageMaker Studio space that mounts an existing EFS file system names it so the space's apps can read and write it. That reference is a mount, not a home: the domain is deployed in its VPC, and the file system is a room of its own that access points are created into. Until now the reference was placement by omission, so a domain whose space mounted an EFS would have been drawn inside the file system's room instead of in its network.
+- The containment-decision registry (`shared/cloudresourcekind/testdata/containment_decisions.txt`) moves exactly that one line from `contained` to `exempt`; nothing else in the registry moved.
+
+## Why
+
+`container_kind` says a kind is a box other resources nest inside, and `containment_exempt` says a reference into such a box is access, not placement. The domain-level mount (`AwsSagemakerDomainEfsFileSystemConfig.file_system_id`) already carries the exemption for exactly this reason; the space-level twin did not, so the same mount drew two different pictures depending on where in the domain it was authored. On a diagram the domain now stands in its VPC with a line to the file system whichever level mounts it.
+
+## How to check
+
+```bash
+go test ./shared/cloudresourcekind/... -run TestContainmentDecisions   # green; the golden carries the exempt line
+grep -n containment_exempt catalog/aws/awssagemakerdomain/v1alpha1/spec.proto
+```

--- a/catalog/aws/awssagemakerdomain/v1alpha1/spec.pb.go
+++ b/catalog/aws/awssagemakerdomain/v1alpha1/spec.pb.go
@@ -1269,6 +1269,11 @@ type AwsSagemakerDomainSpaceCustomFileSystem struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The EFS file system to mount. The file system must have mount targets in
 	// the domain's VPC.
+	//
+	// Containment-exempt: a space MOUNTS the file system; the domain is not
+	// deployed inside it. On a diagram the domain stands in its VPC with a
+	// line to the file system -- the verdict the domain-level
+	// AwsSagemakerDomainEfsFileSystemConfig.file_system_id already carries.
 	FileSystemId  *v1.StringValueOrRef `protobuf:"bytes,1,opt,name=file_system_id,json=fileSystemId,proto3" json:"file_system_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -3288,9 +3293,9 @@ const file_catalog_aws_awssagemakerdomain_v1alpha1_spec_proto_rawDesc = "" +
 	"\ridle_settings\x18\x02 \x01(\v2P.dev.planton.aws.awssagemakerdomain.v1alpha1.AwsSagemakerDomainSpaceIdleSettingsR\fidleSettings\"\x8a\x01\n" +
 	"#AwsSagemakerDomainSpaceIdleSettings\x12G\n" +
 	"\x17idle_timeout_in_minutes\x18\x01 \x01(\x05B\v\xbaH\b\x1a\x06\x18\xa0\x8a (<H\x00R\x14idleTimeoutInMinutes\x88\x01\x01B\x1a\n" +
-	"\x18_idle_timeout_in_minutes\"\xb2\x01\n" +
-	"'AwsSagemakerDomainSpaceCustomFileSystem\x12\x86\x01\n" +
-	"\x0efile_system_id\x18\x01 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB,\xbaH\x03\xc8\x01\x01\x88\xd4a\xc2\b\x92\xd4a\x1dstatus.outputs.file_system_idR\ffileSystemId\"b\n" +
+	"\x18_idle_timeout_in_minutes\"\xb6\x01\n" +
+	"'AwsSagemakerDomainSpaceCustomFileSystem\x12\x8a\x01\n" +
+	"\x0efile_system_id\x18\x01 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB0\xbaH\x03\xc8\x01\x01\x88\xd4a\xc2\b\x92\xd4a\x1dstatus.outputs.file_system_id\x98\xd4a\x01R\ffileSystemId\"b\n" +
 	"\x1eAwsSagemakerDomainSpaceStorage\x12@\n" +
 	"\x15ebs_volume_size_in_gb\x18\x01 \x01(\x05B\x0e\xbaH\v\xc8\x01\x01\x1a\x06\x18\x80\x80\x01(\x05R\x11ebsVolumeSizeInGb\"\x84\x06\n" +
 	"'AwsSagemakerDomainJupyterLabAppSettings\x12\x7f\n" +

--- a/catalog/aws/awssagemakerdomain/v1alpha1/spec.proto
+++ b/catalog/aws/awssagemakerdomain/v1alpha1/spec.proto
@@ -651,9 +651,15 @@ message AwsSagemakerDomainSpaceIdleSettings {
 message AwsSagemakerDomainSpaceCustomFileSystem {
   // The EFS file system to mount. The file system must have mount targets in
   // the domain's VPC.
+  //
+  // Containment-exempt: a space MOUNTS the file system; the domain is not
+  // deployed inside it. On a diagram the domain stands in its VPC with a
+  // line to the file system -- the verdict the domain-level
+  // AwsSagemakerDomainEfsFileSystemConfig.file_system_id already carries.
   dev.planton.shared.foreignkey.v1.StringValueOrRef file_system_id = 1 [
     (buf.validate.field).required = true,
     (dev.planton.shared.foreignkey.v1.default_kind) = AwsElasticFileSystem,
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true,
     (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.file_system_id"
   ];
 }

--- a/shared/cloudresourcekind/testdata/containment_decisions.txt
+++ b/shared/cloudresourcekind/testdata/containment_decisions.txt
@@ -97,7 +97,6 @@ contained dev.planton.aws.awsroute53resolverendpoint.v1alpha1.AwsRoute53Resolver
 contained dev.planton.aws.awsroute53resolverendpoint.v1alpha1.AwsRoute53ResolverEndpointRule.vpc_ids -> AwsVpc
 contained dev.planton.aws.awsroute53resolverfirewall.v1alpha1.AwsRoute53ResolverFirewallVpcAssociation.vpc_id -> AwsVpc
 contained dev.planton.aws.awsroute53resolverquerylog.v1alpha1.AwsRoute53ResolverQueryLogSpec.vpc_ids -> AwsVpc
-contained dev.planton.aws.awssagemakerdomain.v1alpha1.AwsSagemakerDomainSpaceCustomFileSystem.file_system_id -> AwsElasticFileSystem
 contained dev.planton.aws.awssagemakerdomain.v1alpha1.AwsSagemakerDomainSpec.subnet_ids -> AwsSubnet
 contained dev.planton.aws.awssagemakerdomain.v1alpha1.AwsSagemakerDomainSpec.vpc_id -> AwsVpc
 contained dev.planton.aws.awssagemakermodel.v1alpha1.AwsSagemakerModelVpcConfig.subnet_ids -> AwsSubnet
@@ -680,6 +679,7 @@ exempt    dev.planton.aws.awsnlb.v1alpha1.AwsNlbDns.route53_zone_id -> AwsRoute5
 exempt    dev.planton.aws.awsopensearchdomain.v1alpha1.AwsOpenSearchDomainCognitoOptions.user_pool_id -> AwsCognitoUserPool
 exempt    dev.planton.aws.awsroute53zone.v1alpha1.AwsRoute53ZoneVpcAssociation.vpc_id -> AwsVpc
 exempt    dev.planton.aws.awssagemakerdomain.v1alpha1.AwsSagemakerDomainEfsFileSystemConfig.file_system_id -> AwsElasticFileSystem
+exempt    dev.planton.aws.awssagemakerdomain.v1alpha1.AwsSagemakerDomainSpaceCustomFileSystem.file_system_id -> AwsElasticFileSystem
 exempt    dev.planton.aws.awssesconfigurationset.v1alpha1.AwsSesConfigurationSetEventDestination.event_bus -> AwsEventBridgeBus
 exempt    dev.planton.aws.awsvpcendpoint.v1alpha1.AwsVpcEndpointSpec.route_table_ids -> AwsSubnet
 exempt    dev.planton.azure.azureakscluster.v1alpha1.AzureAksClusterServiceMeshCertificateAuthority.key_vault_id -> AzureKeyVault


### PR DESCRIPTION
## What

One SageMaker reference becomes `containment_exempt`:

- `AwsSagemakerDomainSpaceCustomFileSystem.file_system_id` -- the EFS file system a Studio space mounts into its apps

The field's comment states the verdict and its precedent. Go stubs regenerated with the pinned `protoc-gen-go v1.36.6`. The containment-decision registry moves exactly this one line from `contained` to `exempt`; nothing else moved.

## Why

A Studio domain is deployed in its VPC. An EFS file system is a room of its own (access points are created into it), and a space that mounts one names it for access, not as a home. The domain-level mount (`AwsSagemakerDomainEfsFileSystemConfig.file_system_id`) already carries the exemption for exactly this reason; the space-level twin did not, so the same mount drew two different pictures depending on where in the domain it was authored -- a domain whose space mounted an EFS would have been drawn inside the file system instead of in its network. On a diagram the domain now stands in its VPC with a line to the file system whichever level mounts it.

## Test plan

- [x] `buf lint` and `buf format -d` clean on the package
- [x] `go test ./shared/cloudresourcekind/...` green with exactly one golden line moved
- [x] Changelog entry under `_changelog/2026-09/`