### PR TITLE
fix(catalog/aws): an AgentCore runtime, gateway, or harness that reaches through a VPC never lives in it on a diagram

### DIFF
--- a/_changelog/2026-09/2026-09-08-091500-an-agentcore-runtime-gateway-or-harness-that-reaches-through-a-vpc-never-lives-in-it-on-a-diagram.md
+++ b/_changelog/2026-09/2026-09-08-091500-an-agentcore-runtime-gateway-or-harness-that-reaches-through-a-vpc-never-lives-in-it-on-a-diagram.md
@@ -1,0 +1,17 @@
+# An AgentCore runtime, gateway, or harness that reaches through a VPC never lives in it on a diagram
+
+## What changed
+
+- **The three AgentCore managed VPC endpoint blocks are containment-exempt on both of their network references.** `AwsBedrockAgentCoreManagedVpcEndpoint.vpc_id` and `.subnet_ids` on the agent runtime, `AwsBedrockAgentCoreGatewayManagedVpcEndpoint.vpc_id` and `.subnet_ids` on the gateway, and `AwsBedrockAgentCoreManagedVpcEndpoint.vpc_id` and `.subnet_ids` on the evaluation harness. A managed endpoint is an AWS-managed private PATH through your VPC so the runtime, gateway, or harness can reach a private OIDC provider or a private backend; the resource itself is not deployed inside that VPC. Until now the references were placement by omission, so a gateway whose one target sat behind a private endpoint would have been drawn inside the VPC it merely reaches into.
+- The containment-decision registry (`shared/cloudresourcekind/testdata/containment_decisions.txt`) moves exactly those six lines from `contained` to `exempt`; nothing else in the registry moved.
+
+## Why
+
+`container_kind` says a kind is a box other resources nest inside, and `containment_exempt` says a reference into such a box is access, not placement. Where an AgentCore resource genuinely runs inside a network -- a runtime, a browser tool, or a harness in VPC network mode attaching session interfaces to your subnets -- its `VpcConfig.subnets` stays placement and the diagram draws it in the VPC. A private endpoint is the other thing: a door punched through the VPC wall for outbound reach. The same verdict already stands on a Lambda's VPC subnets and an EventBridge pipe's task subnets. On a diagram the runtime, the gateway, and the harness now stand where their own network places them, with a line into the VPC they reach through.
+
+## How to check
+
+```bash
+go test ./shared/cloudresourcekind/... -run TestContainmentDecisions   # green; the golden carries the six exempt lines
+grep -n containment_exempt catalog/aws/awsbedrockagentcoreruntime/v1alpha1/spec.proto catalog/aws/awsbedrockagentcoregateway/v1alpha1/spec.proto catalog/aws/awsbedrockagentcoreevaluation/v1alpha1/spec.proto
+```

--- a/catalog/aws/awsbedrockagentcoreevaluation/v1alpha1/spec.pb.go
+++ b/catalog/aws/awsbedrockagentcoreevaluation/v1alpha1/spec.pb.go
@@ -2749,9 +2749,16 @@ func (x *AwsBedrockAgentCorePrivateEndpoint) GetSelfManagedLattice() *AwsBedrock
 type AwsBedrockAgentCoreManagedVpcEndpoint struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The VPC to route through.
+	//
+	// Containment-exempt: a managed endpoint is a private PATH through the
+	// VPC to a private provider or backend; the harness is not deployed inside
+	// it. On a diagram it stands where its own network places it, with a
+	// line into the VPC -- the verdict a Lambda's VPC subnets and an
+	// EventBridge pipe's task subnets already carry.
 	VpcId *v1.StringValueOrRef `protobuf:"bytes,1,opt,name=vpc_id,json=vpcId,proto3" json:"vpc_id,omitempty"`
 	// Subnets for the managed endpoint's network interfaces (at least
 	// one).
+	// Containment-exempt for the same reason as the VPC above.
 	SubnetIds []*v1.StringValueOrRef `protobuf:"bytes,2,rep,name=subnet_ids,json=subnetIds,proto3" json:"subnet_ids,omitempty"`
 	// Security groups on the endpoint interfaces (max 5).
 	SecurityGroupIds []*v1.StringValueOrRef `protobuf:"bytes,3,rep,name=security_group_ids,json=securityGroupIds,proto3" json:"security_group_ids,omitempty"`
@@ -3532,11 +3539,11 @@ const file_catalog_aws_awsbedrockagentcoreevaluation_v1alpha1_spec_proto_rawDesc
 	"\vmanaged_vpc\x18\x01 \x01(\v2].dev.planton.aws.awsbedrockagentcoreevaluation.v1alpha1.AwsBedrockAgentCoreManagedVpcEndpointR\n" +
 	"managedVpc\x12\x8c\x01\n" +
 	"\x14self_managed_lattice\x18\x02 \x01(\v2Z.dev.planton.aws.awsbedrockagentcoreevaluation.v1alpha1.AwsBedrockAgentCoreLatticeEndpointR\x12selfManagedLattice:\xac\x01\xbaH\xa8\x01\x1a\xa5\x01\n" +
-	"\x1cprivate_endpoint_exactly_one\x12Lprivate endpoint must set exactly one of managed_vpc or self_managed_lattice\x1a7has(this.managed_vpc) != has(this.self_managed_lattice)\"\xe7\x05\n" +
-	"%AwsBedrockAgentCoreManagedVpcEndpoint\x12o\n" +
-	"\x06vpc_id\x18\x01 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB$\xbaH\x03\xc8\x01\x01\x88\xd4a\xf8\a\x92\xd4a\x15status.outputs.vpc_idR\x05vpcId\x12\x7f\n" +
+	"\x1cprivate_endpoint_exactly_one\x12Lprivate endpoint must set exactly one of managed_vpc or self_managed_lattice\x1a7has(this.managed_vpc) != has(this.self_managed_lattice)\"\xf0\x05\n" +
+	"%AwsBedrockAgentCoreManagedVpcEndpoint\x12s\n" +
+	"\x06vpc_id\x18\x01 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB(\xbaH\x03\xc8\x01\x01\x88\xd4a\xf8\a\x92\xd4a\x15status.outputs.vpc_id\x98\xd4a\x01R\x05vpcId\x12\x83\x01\n" +
 	"\n" +
-	"subnet_ids\x18\x02 \x03(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB,\xbaH\b\xc8\x01\x01\x92\x01\x02\b\x01\x88\xd4a\xbc\b\x92\xd4a\x18status.outputs.subnet_idR\tsubnetIds\x12\x93\x01\n" +
+	"subnet_ids\x18\x02 \x03(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB0\xbaH\b\xc8\x01\x01\x92\x01\x02\b\x01\x88\xd4a\xbc\b\x92\xd4a\x18status.outputs.subnet_id\x98\xd4a\x01R\tsubnetIds\x12\x93\x01\n" +
 	"\x12security_group_ids\x18\x03 \x03(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB1\xbaH\x05\x92\x01\x02\x10\x05\x88\xd4a\xf7\a\x92\xd4a status.outputs.security_group_idR\x10securityGroupIds\x12J\n" +
 	"\x18endpoint_ip_address_type\x18\x04 \x01(\tB\x11\xbaH\x0er\fR\x04IPV4R\x04IPV6R\x15endpointIpAddressType\x124\n" +
 	"\x0erouting_domain\x18\x05 \x01(\tB\r\xbaH\n" +

--- a/catalog/aws/awsbedrockagentcoreevaluation/v1alpha1/spec.proto
+++ b/catalog/aws/awsbedrockagentcoreevaluation/v1alpha1/spec.proto
@@ -1028,18 +1028,27 @@ message AwsBedrockAgentCorePrivateEndpoint {
 // explicitly - unlike the agent runtime's otherwise-identical shape.)
 message AwsBedrockAgentCoreManagedVpcEndpoint {
   // The VPC to route through.
+  //
+  // Containment-exempt: a managed endpoint is a private PATH through the
+  // VPC to a private provider or backend; the harness is not deployed inside
+  // it. On a diagram it stands where its own network places it, with a
+  // line into the VPC -- the verdict a Lambda's VPC subnets and an
+  // EventBridge pipe's task subnets already carry.
   dev.planton.shared.foreignkey.v1.StringValueOrRef vpc_id = 1 [
     (buf.validate.field).required = true,
     (dev.planton.shared.foreignkey.v1.default_kind) = AwsVpc,
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true,
     (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.vpc_id"
   ];
 
   // Subnets for the managed endpoint's network interfaces (at least
   // one).
+  // Containment-exempt for the same reason as the VPC above.
   repeated dev.planton.shared.foreignkey.v1.StringValueOrRef subnet_ids = 2 [
     (buf.validate.field).required = true,
     (buf.validate.field).repeated.min_items = 1,
     (dev.planton.shared.foreignkey.v1.default_kind) = AwsSubnet,
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true,
     (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.subnet_id"
   ];
 

--- a/catalog/aws/awsbedrockagentcoregateway/v1alpha1/spec.pb.go
+++ b/catalog/aws/awsbedrockagentcoregateway/v1alpha1/spec.pb.go
@@ -506,8 +506,15 @@ func (x *AwsBedrockAgentCoreGatewayPrivateEndpoint) GetSelfManagedLattice() *Aws
 type AwsBedrockAgentCoreGatewayManagedVpcEndpoint struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The VPC to route through.
+	//
+	// Containment-exempt: a managed endpoint is a private PATH through the
+	// VPC to a private provider or backend; the gateway is not deployed inside
+	// it. On a diagram it stands where its own network places it, with a
+	// line into the VPC -- the verdict a Lambda's VPC subnets and an
+	// EventBridge pipe's task subnets already carry.
 	VpcId *v1.StringValueOrRef `protobuf:"bytes,1,opt,name=vpc_id,json=vpcId,proto3" json:"vpc_id,omitempty"`
 	// Subnets for the managed endpoint's network interfaces (at least one).
+	// Containment-exempt for the same reason as the VPC above.
 	SubnetIds []*v1.StringValueOrRef `protobuf:"bytes,2,rep,name=subnet_ids,json=subnetIds,proto3" json:"subnet_ids,omitempty"`
 	// Security groups on the endpoint interfaces (max 5).
 	SecurityGroupIds []*v1.StringValueOrRef `protobuf:"bytes,3,rep,name=security_group_ids,json=securityGroupIds,proto3" json:"security_group_ids,omitempty"`
@@ -2514,11 +2521,11 @@ const file_catalog_aws_awsbedrockagentcoregateway_v1alpha1_spec_proto_rawDesc = 
 	"\vmanaged_vpc\x18\x01 \x01(\v2a.dev.planton.aws.awsbedrockagentcoregateway.v1alpha1.AwsBedrockAgentCoreGatewayManagedVpcEndpointR\n" +
 	"managedVpc\x12\x90\x01\n" +
 	"\x14self_managed_lattice\x18\x02 \x01(\v2^.dev.planton.aws.awsbedrockagentcoregateway.v1alpha1.AwsBedrockAgentCoreGatewayLatticeEndpointR\x12selfManagedLattice:\xac\x01\xbaH\xa8\x01\x1a\xa5\x01\n" +
-	"\x1cprivate_endpoint_exactly_one\x12Lprivate endpoint must set exactly one of managed_vpc or self_managed_lattice\x1a7has(this.managed_vpc) != has(this.self_managed_lattice)\"\xf0\x05\n" +
-	",AwsBedrockAgentCoreGatewayManagedVpcEndpoint\x12o\n" +
-	"\x06vpc_id\x18\x01 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB$\xbaH\x03\xc8\x01\x01\x88\xd4a\xf8\a\x92\xd4a\x15status.outputs.vpc_idR\x05vpcId\x12\x7f\n" +
+	"\x1cprivate_endpoint_exactly_one\x12Lprivate endpoint must set exactly one of managed_vpc or self_managed_lattice\x1a7has(this.managed_vpc) != has(this.self_managed_lattice)\"\xf9\x05\n" +
+	",AwsBedrockAgentCoreGatewayManagedVpcEndpoint\x12s\n" +
+	"\x06vpc_id\x18\x01 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB(\xbaH\x03\xc8\x01\x01\x88\xd4a\xf8\a\x92\xd4a\x15status.outputs.vpc_id\x98\xd4a\x01R\x05vpcId\x12\x83\x01\n" +
 	"\n" +
-	"subnet_ids\x18\x02 \x03(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB,\xbaH\b\xc8\x01\x01\x92\x01\x02\b\x01\x88\xd4a\xbc\b\x92\xd4a\x18status.outputs.subnet_idR\tsubnetIds\x12\x93\x01\n" +
+	"subnet_ids\x18\x02 \x03(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB0\xbaH\b\xc8\x01\x01\x92\x01\x02\b\x01\x88\xd4a\xbc\b\x92\xd4a\x18status.outputs.subnet_id\x98\xd4a\x01R\tsubnetIds\x12\x93\x01\n" +
 	"\x12security_group_ids\x18\x03 \x03(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB1\xbaH\x05\x92\x01\x02\x10\x05\x88\xd4a\xf7\a\x92\xd4a status.outputs.security_group_idR\x10securityGroupIds\x12J\n" +
 	"\x18endpoint_ip_address_type\x18\x04 \x01(\tB\x11\xbaH\x0er\fR\x04IPV4R\x04IPV6R\x15endpointIpAddressType\x122\n" +
 	"\x0erouting_domain\x18\x05 \x01(\tB\v\xbaH\b\xd8\x01\x01r\x03\x18\xff\x01R\rroutingDomain\x12\x7f\n" +

--- a/catalog/aws/awsbedrockagentcoregateway/v1alpha1/spec.proto
+++ b/catalog/aws/awsbedrockagentcoregateway/v1alpha1/spec.proto
@@ -230,17 +230,26 @@ message AwsBedrockAgentCoreGatewayPrivateEndpoint {
 // path through your VPC.
 message AwsBedrockAgentCoreGatewayManagedVpcEndpoint {
   // The VPC to route through.
+  //
+  // Containment-exempt: a managed endpoint is a private PATH through the
+  // VPC to a private provider or backend; the gateway is not deployed inside
+  // it. On a diagram it stands where its own network places it, with a
+  // line into the VPC -- the verdict a Lambda's VPC subnets and an
+  // EventBridge pipe's task subnets already carry.
   dev.planton.shared.foreignkey.v1.StringValueOrRef vpc_id = 1 [
     (buf.validate.field).required = true,
     (dev.planton.shared.foreignkey.v1.default_kind) = AwsVpc,
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true,
     (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.vpc_id"
   ];
 
   // Subnets for the managed endpoint's network interfaces (at least one).
+  // Containment-exempt for the same reason as the VPC above.
   repeated dev.planton.shared.foreignkey.v1.StringValueOrRef subnet_ids = 2 [
     (buf.validate.field).required = true,
     (buf.validate.field).repeated.min_items = 1,
     (dev.planton.shared.foreignkey.v1.default_kind) = AwsSubnet,
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true,
     (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.subnet_id"
   ];
 

--- a/catalog/aws/awsbedrockagentcoreruntime/v1alpha1/spec.pb.go
+++ b/catalog/aws/awsbedrockagentcoreruntime/v1alpha1/spec.pb.go
@@ -948,8 +948,15 @@ func (x *AwsBedrockAgentCorePrivateEndpoint) GetSelfManagedLattice() *AwsBedrock
 type AwsBedrockAgentCoreManagedVpcEndpoint struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The VPC to route through.
+	//
+	// Containment-exempt: a managed endpoint is a private PATH through the
+	// VPC to a private provider or backend; the runtime is not deployed inside
+	// it. On a diagram it stands where its own network places it, with a
+	// line into the VPC -- the verdict a Lambda's VPC subnets and an
+	// EventBridge pipe's task subnets already carry.
 	VpcId *v1.StringValueOrRef `protobuf:"bytes,1,opt,name=vpc_id,json=vpcId,proto3" json:"vpc_id,omitempty"`
 	// Subnets for the managed endpoint's network interfaces (at least one).
+	// Containment-exempt for the same reason as the VPC above.
 	SubnetIds []*v1.StringValueOrRef `protobuf:"bytes,2,rep,name=subnet_ids,json=subnetIds,proto3" json:"subnet_ids,omitempty"`
 	// Security groups on the endpoint interfaces (max 5).
 	SecurityGroupIds []*v1.StringValueOrRef `protobuf:"bytes,3,rep,name=security_group_ids,json=securityGroupIds,proto3" json:"security_group_ids,omitempty"`
@@ -1371,11 +1378,11 @@ const file_catalog_aws_awsbedrockagentcoreruntime_v1alpha1_spec_proto_rawDesc = 
 	"\vmanaged_vpc\x18\x01 \x01(\v2Z.dev.planton.aws.awsbedrockagentcoreruntime.v1alpha1.AwsBedrockAgentCoreManagedVpcEndpointR\n" +
 	"managedVpc\x12\x89\x01\n" +
 	"\x14self_managed_lattice\x18\x02 \x01(\v2W.dev.planton.aws.awsbedrockagentcoreruntime.v1alpha1.AwsBedrockAgentCoreLatticeEndpointR\x12selfManagedLattice:\xac\x01\xbaH\xa8\x01\x1a\xa5\x01\n" +
-	"\x1cprivate_endpoint_exactly_one\x12Lprivate endpoint must set exactly one of managed_vpc or self_managed_lattice\x1a7has(this.managed_vpc) != has(this.self_managed_lattice)\"\xe2\x05\n" +
-	"%AwsBedrockAgentCoreManagedVpcEndpoint\x12o\n" +
-	"\x06vpc_id\x18\x01 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB$\xbaH\x03\xc8\x01\x01\x88\xd4a\xf8\a\x92\xd4a\x15status.outputs.vpc_idR\x05vpcId\x12\x7f\n" +
+	"\x1cprivate_endpoint_exactly_one\x12Lprivate endpoint must set exactly one of managed_vpc or self_managed_lattice\x1a7has(this.managed_vpc) != has(this.self_managed_lattice)\"\xeb\x05\n" +
+	"%AwsBedrockAgentCoreManagedVpcEndpoint\x12s\n" +
+	"\x06vpc_id\x18\x01 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB(\xbaH\x03\xc8\x01\x01\x88\xd4a\xf8\a\x92\xd4a\x15status.outputs.vpc_id\x98\xd4a\x01R\x05vpcId\x12\x83\x01\n" +
 	"\n" +
-	"subnet_ids\x18\x02 \x03(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB,\xbaH\b\xc8\x01\x01\x92\x01\x02\b\x01\x88\xd4a\xbc\b\x92\xd4a\x18status.outputs.subnet_idR\tsubnetIds\x12\x93\x01\n" +
+	"subnet_ids\x18\x02 \x03(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB0\xbaH\b\xc8\x01\x01\x92\x01\x02\b\x01\x88\xd4a\xbc\b\x92\xd4a\x18status.outputs.subnet_id\x98\xd4a\x01R\tsubnetIds\x12\x93\x01\n" +
 	"\x12security_group_ids\x18\x03 \x03(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB1\xbaH\x05\x92\x01\x02\x10\x05\x88\xd4a\xf7\a\x92\xd4a status.outputs.security_group_idR\x10securityGroupIds\x12J\n" +
 	"\x18endpoint_ip_address_type\x18\x04 \x01(\tB\x11\xbaH\x0er\fR\x04IPV4R\x04IPV6R\x15endpointIpAddressType\x122\n" +
 	"\x0erouting_domain\x18\x05 \x01(\tB\v\xbaH\b\xd8\x01\x01r\x03\x18\xff\x01R\rroutingDomain\x12x\n" +

--- a/catalog/aws/awsbedrockagentcoreruntime/v1alpha1/spec.proto
+++ b/catalog/aws/awsbedrockagentcoreruntime/v1alpha1/spec.proto
@@ -392,17 +392,26 @@ message AwsBedrockAgentCorePrivateEndpoint {
 // through your VPC.
 message AwsBedrockAgentCoreManagedVpcEndpoint {
   // The VPC to route through.
+  //
+  // Containment-exempt: a managed endpoint is a private PATH through the
+  // VPC to a private provider or backend; the runtime is not deployed inside
+  // it. On a diagram it stands where its own network places it, with a
+  // line into the VPC -- the verdict a Lambda's VPC subnets and an
+  // EventBridge pipe's task subnets already carry.
   dev.planton.shared.foreignkey.v1.StringValueOrRef vpc_id = 1 [
     (buf.validate.field).required = true,
     (dev.planton.shared.foreignkey.v1.default_kind) = AwsVpc,
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true,
     (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.vpc_id"
   ];
 
   // Subnets for the managed endpoint's network interfaces (at least one).
+  // Containment-exempt for the same reason as the VPC above.
   repeated dev.planton.shared.foreignkey.v1.StringValueOrRef subnet_ids = 2 [
     (buf.validate.field).required = true,
     (buf.validate.field).repeated.min_items = 1,
     (dev.planton.shared.foreignkey.v1.default_kind) = AwsSubnet,
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true,
     (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.subnet_id"
   ];
 

--- a/shared/cloudresourcekind/testdata/containment_decisions.txt
+++ b/shared/cloudresourcekind/testdata/containment_decisions.txt
@@ -15,12 +15,6 @@ contained dev.planton.aws.awsautoscalinggroup.v1alpha1.AwsAutoScalingGroupSpec.s
 contained dev.planton.aws.awsbatchcomputeenvironment.v1alpha1.AwsBatchComputeResources.subnet_ids -> AwsSubnet
 contained dev.planton.aws.awsbatchcomputeenvironment.v1alpha1.AwsBatchEksConfiguration.eks_cluster_arn -> AwsEksCluster
 contained dev.planton.aws.awsbedrockagentcoreevaluation.v1alpha1.AwsBedrockAgentCoreHarnessVpcConfig.subnets -> AwsSubnet
-contained dev.planton.aws.awsbedrockagentcoreevaluation.v1alpha1.AwsBedrockAgentCoreManagedVpcEndpoint.subnet_ids -> AwsSubnet
-contained dev.planton.aws.awsbedrockagentcoreevaluation.v1alpha1.AwsBedrockAgentCoreManagedVpcEndpoint.vpc_id -> AwsVpc
-contained dev.planton.aws.awsbedrockagentcoregateway.v1alpha1.AwsBedrockAgentCoreGatewayManagedVpcEndpoint.subnet_ids -> AwsSubnet
-contained dev.planton.aws.awsbedrockagentcoregateway.v1alpha1.AwsBedrockAgentCoreGatewayManagedVpcEndpoint.vpc_id -> AwsVpc
-contained dev.planton.aws.awsbedrockagentcoreruntime.v1alpha1.AwsBedrockAgentCoreManagedVpcEndpoint.subnet_ids -> AwsSubnet
-contained dev.planton.aws.awsbedrockagentcoreruntime.v1alpha1.AwsBedrockAgentCoreManagedVpcEndpoint.vpc_id -> AwsVpc
 contained dev.planton.aws.awsbedrockagentcoreruntime.v1alpha1.AwsBedrockAgentCoreVpcConfig.subnets -> AwsSubnet
 contained dev.planton.aws.awsbedrockagentcoretools.v1alpha1.AwsBedrockAgentCoreToolVpcConfig.subnets -> AwsSubnet
 contained dev.planton.aws.awsbedrockcustommodel.v1alpha1.AwsBedrockCustomModelVpcConfig.subnet_ids -> AwsSubnet
@@ -658,6 +652,12 @@ contained dev.planton.openfga.openfgaauthorizationmodel.v1alpha1.OpenFgaAuthoriz
 contained dev.planton.openfga.openfgarelationshiptuple.v1alpha1.OpenFgaRelationshipTupleSpec.store_id -> OpenFgaStore
 exempt    dev.planton.aws.awsalb.v1alpha1.AwsAlbDns.route53_zone_id -> AwsRoute53Zone
 exempt    dev.planton.aws.awsbatchjobdefinition.v1alpha1.AwsBatchJobDefinitionEfsVolume.file_system_id -> AwsElasticFileSystem
+exempt    dev.planton.aws.awsbedrockagentcoreevaluation.v1alpha1.AwsBedrockAgentCoreManagedVpcEndpoint.subnet_ids -> AwsSubnet
+exempt    dev.planton.aws.awsbedrockagentcoreevaluation.v1alpha1.AwsBedrockAgentCoreManagedVpcEndpoint.vpc_id -> AwsVpc
+exempt    dev.planton.aws.awsbedrockagentcoregateway.v1alpha1.AwsBedrockAgentCoreGatewayManagedVpcEndpoint.subnet_ids -> AwsSubnet
+exempt    dev.planton.aws.awsbedrockagentcoregateway.v1alpha1.AwsBedrockAgentCoreGatewayManagedVpcEndpoint.vpc_id -> AwsVpc
+exempt    dev.planton.aws.awsbedrockagentcoreruntime.v1alpha1.AwsBedrockAgentCoreManagedVpcEndpoint.subnet_ids -> AwsSubnet
+exempt    dev.planton.aws.awsbedrockagentcoreruntime.v1alpha1.AwsBedrockAgentCoreManagedVpcEndpoint.vpc_id -> AwsVpc
 exempt    dev.planton.aws.awscertmanagercert.v1alpha1.AwsCertManagerCertSpec.route53_hosted_zone_id -> AwsRoute53Zone
 exempt    dev.planton.aws.awsclientvpn.v1alpha1.AwsClientVpnRoute.target_subnet_id -> AwsSubnet
 exempt    dev.planton.aws.awsecscluster.v1alpha1.AwsEcsClusterManagedInstancesNetworkConfiguration.subnets -> AwsSubnet


### PR DESCRIPTION
## What

Six AgentCore references become `containment_exempt` -- the `vpc_id` and `subnet_ids` of the managed VPC endpoint block on three kinds:

- `AwsBedrockAgentCoreManagedVpcEndpoint` on the agent runtime (`catalog/aws/awsbedrockagentcoreruntime`)
- `AwsBedrockAgentCoreGatewayManagedVpcEndpoint` on the gateway (`catalog/aws/awsbedrockagentcoregateway`)
- `AwsBedrockAgentCoreManagedVpcEndpoint` on the evaluation harness (`catalog/aws/awsbedrockagentcoreevaluation`)

Each field's comment states the verdict and its precedent. Go stubs regenerated with the pinned `protoc-gen-go v1.36.6`. The containment-decision registry moves exactly these six lines from `contained` to `exempt`; nothing else moved.

## Why

A managed VPC endpoint is an AWS-managed private PATH through your VPC so the runtime, gateway, or harness can reach a private OIDC provider or a private backend. The resource is not deployed inside that VPC -- where an AgentCore resource genuinely runs in a network (VPC network mode, `VpcConfig.subnets`), that reference stays placement and is untouched here. Until now the endpoint's references were placement by omission, so a gateway whose one target sat behind a private endpoint would have been drawn inside the VPC it merely reaches into. The same verdict already stands on a Lambda's VPC subnets and an EventBridge pipe's task subnets (#532). On a diagram the runtime, the gateway, and the harness now stand where their own network places them, with a line into the VPC they reach through.

## Test plan

- [x] `buf lint` and `buf format -d` clean on the three packages
- [x] `go test ./shared/cloudresourcekind/...` green with exactly six golden lines moved
- [x] Changelog entry under `_changelog/2026-09/`