### PR TITLE
fix(catalog/aws): a Prometheus scraper reads the EKS cluster it scrapes and never lives in it on a diagram

### DIFF
--- a/_changelog/2026-09/2026-09-08-140500-a-prometheus-scraper-reads-the-eks-cluster-it-scrapes-and-never-lives-in-it-on-a-diagram.md
+++ b/_changelog/2026-09/2026-09-08-140500-a-prometheus-scraper-reads-the-eks-cluster-it-scrapes-and-never-lives-in-it-on-a-diagram.md
@@ -1,0 +1,17 @@
+# A Prometheus scraper reads the EKS cluster it scrapes and never lives in it on a diagram
+
+## What changed
+
+- **The Managed Prometheus scraper's EKS cluster reference is containment-exempt.** `AwsManagedPrometheusScraperEksSource.cluster_arn` names the cluster the scraper reads metrics from. The scraper's collectors run on AWS-managed network interfaces in the subnets the same source block names; they are never workloads inside the cluster. Until now the reference was placement by omission, so a scraper pointed at an EKS cluster would have been drawn inside the cluster it merely reads -- or, because it also names two subnets, inside whichever of the three candidates happened to sort last.
+- The containment-decision registry (`shared/cloudresourcekind/testdata/containment_decisions.txt`) moves exactly that one line from `contained` to `exempt`; nothing else in the registry moved.
+
+## Why
+
+`container_kind` says a kind is a box other resources nest inside, and `containment_exempt` says a reference into such a box is access, not placement. Every other reference into an EKS cluster in the catalog is a resource that genuinely runs in the cluster -- a node group, an add-on, a Fargate profile, an access entry, a Batch environment on EKS -- and stays placement. The scraper is the one reader: it observes the cluster from outside. On a diagram it now stands where its subnets place it, inside the VPC beside the cluster, with a line to the cluster it scrapes.
+
+## How to check
+
+```bash
+go test ./shared/cloudresourcekind/... -run TestContainmentDecisions   # green; the golden carries the exempt line
+grep -n containment_exempt catalog/aws/awsmanagedprometheusscraper/v1alpha1/spec.proto
+```

--- a/catalog/aws/awsmanagedprometheusscraper/v1alpha1/spec.pb.go
+++ b/catalog/aws/awsmanagedprometheusscraper/v1alpha1/spec.pb.go
@@ -166,6 +166,12 @@ type AwsManagedPrometheusScraperEksSource struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The EKS cluster to scrape. Reference an AwsEksCluster cluster_arn
 	// output or pass a literal ARN.
+	//
+	// Containment-exempt: the scraper READS the cluster's metrics; its
+	// collectors run on AWS-managed interfaces in the subnets below, never
+	// as workloads inside the cluster. On a diagram the scraper stands where
+	// its subnets place it, with a line to the cluster it scrapes -- the
+	// verdict every other reader of a room already carries.
 	ClusterArn *v1.StringValueOrRef `protobuf:"bytes,1,opt,name=cluster_arn,json=clusterArn,proto3" json:"cluster_arn,omitempty"`
 	// Subnets the scraper's collectors place into (the cluster's
 	// subnets). Reference AwsSubnet subnet_id outputs or pass literal
@@ -429,9 +435,9 @@ const file_catalog_aws_awsmanagedprometheusscraper_v1alpha1_spec_proto_rawDesc =
 	"\x17spec.exactly_one_source\x122configure exactly one of source_eks and source_vpc\x1a,has(this.source_eks) != has(this.source_vpc)\x1a\xa6\x01\n" +
 	"\x1cspec.exactly_one_destination\x12Econfigure exactly one of amp_workspace_arn and cloudwatch_dataset_arn\x1a?has(this.amp_workspace_arn) != has(this.cloudwatch_dataset_arn)\x1a\xd5\x01\n" +
 	"-spec.vpc_source_requires_scrape_configuration\x12jscrape_configuration is required with source_vpc - AWS's default configuration exists only for EKS sources\x1a8!has(this.source_vpc) || this.scrape_configuration != ''\x1a\xd9\x01\n" +
-	"\x1cspec.role_configuration_pair\x128source_role_arn and target_role_arn must be set together\x1a\x7f!has(this.role_configuration) || (has(this.role_configuration.source_role_arn) == has(this.role_configuration.target_role_arn))\"\xb2\x03\n" +
-	"$AwsManagedPrometheusScraperEksSource\x12~\n" +
-	"\vcluster_arn\x18\x01 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB)\xbaH\x03\xc8\x01\x01\x88\xd4a\xef\a\x92\xd4a\x1astatus.outputs.cluster_arnR\n" +
+	"\x1cspec.role_configuration_pair\x128source_role_arn and target_role_arn must be set together\x1a\x7f!has(this.role_configuration) || (has(this.role_configuration.source_role_arn) == has(this.role_configuration.target_role_arn))\"\xb7\x03\n" +
+	"$AwsManagedPrometheusScraperEksSource\x12\x82\x01\n" +
+	"\vcluster_arn\x18\x01 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB-\xbaH\x03\xc8\x01\x01\x88\xd4a\xef\a\x92\xd4a\x1astatus.outputs.cluster_arn\x98\xd4a\x01R\n" +
 	"clusterArn\x12|\n" +
 	"\n" +
 	"subnet_ids\x18\x02 \x03(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB)\xbaH\x05\x92\x01\x02\b\x02\x88\xd4a\xbc\b\x92\xd4a\x18status.outputs.subnet_idR\tsubnetIds\x12\x8b\x01\n" +

--- a/catalog/aws/awsmanagedprometheusscraper/v1alpha1/spec.proto
+++ b/catalog/aws/awsmanagedprometheusscraper/v1alpha1/spec.proto
@@ -88,9 +88,16 @@ message AwsManagedPrometheusScraperSpec {
 message AwsManagedPrometheusScraperEksSource {
   // The EKS cluster to scrape. Reference an AwsEksCluster cluster_arn
   // output or pass a literal ARN.
+  //
+  // Containment-exempt: the scraper READS the cluster's metrics; its
+  // collectors run on AWS-managed interfaces in the subnets below, never
+  // as workloads inside the cluster. On a diagram the scraper stands where
+  // its subnets place it, with a line to the cluster it scrapes -- the
+  // verdict every other reader of a room already carries.
   dev.planton.shared.foreignkey.v1.StringValueOrRef cluster_arn = 1 [
     (buf.validate.field).required = true,
     (dev.planton.shared.foreignkey.v1.default_kind) = AwsEksCluster,
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true,
     (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.cluster_arn"
   ];
 

--- a/shared/cloudresourcekind/testdata/containment_decisions.txt
+++ b/shared/cloudresourcekind/testdata/containment_decisions.txt
@@ -65,7 +65,6 @@ contained dev.planton.aws.awshttpapivpclink.v1alpha1.AwsHttpApiVpcLinkSpec.subne
 contained dev.planton.aws.awsinternetgateway.v1alpha1.AwsInternetGatewaySpec.vpc_id -> AwsVpc
 contained dev.planton.aws.awslaunchtemplate.v1alpha1.AwsLaunchTemplateSecondaryInterface.secondary_subnet_id -> AwsSubnet
 contained dev.planton.aws.awslbtargetgroup.v1alpha1.AwsLbTargetGroupSpec.vpc_id -> AwsVpc
-contained dev.planton.aws.awsmanagedprometheusscraper.v1alpha1.AwsManagedPrometheusScraperEksSource.cluster_arn -> AwsEksCluster
 contained dev.planton.aws.awsmanagedprometheusscraper.v1alpha1.AwsManagedPrometheusScraperEksSource.subnet_ids -> AwsSubnet
 contained dev.planton.aws.awsmanagedprometheusscraper.v1alpha1.AwsManagedPrometheusScraperVpcSource.subnet_ids -> AwsSubnet
 contained dev.planton.aws.awsmemcachedelasticache.v1alpha1.AwsMemcachedElasticacheSpec.subnet_ids -> AwsSubnet
@@ -676,6 +675,7 @@ exempt    dev.planton.aws.awslblistener.v1alpha1.AwsLbListenerActionAuthenticate
 exempt    dev.planton.aws.awslblistener.v1alpha1.AwsLbListenerActionAuthenticateCognito.user_pool_domain -> AwsCognitoUserPool
 exempt    dev.planton.aws.awslblistenerrule.v1alpha1.AwsLbListenerRuleActionAuthenticateCognito.user_pool_arn -> AwsCognitoUserPool
 exempt    dev.planton.aws.awslblistenerrule.v1alpha1.AwsLbListenerRuleActionAuthenticateCognito.user_pool_domain -> AwsCognitoUserPool
+exempt    dev.planton.aws.awsmanagedprometheusscraper.v1alpha1.AwsManagedPrometheusScraperEksSource.cluster_arn -> AwsEksCluster
 exempt    dev.planton.aws.awsnlb.v1alpha1.AwsNlbDns.route53_zone_id -> AwsRoute53Zone
 exempt    dev.planton.aws.awsopensearchdomain.v1alpha1.AwsOpenSearchDomainCognitoOptions.user_pool_id -> AwsCognitoUserPool
 exempt    dev.planton.aws.awsroute53zone.v1alpha1.AwsRoute53ZoneVpcAssociation.vpc_id -> AwsVpc


### PR DESCRIPTION
## What

`AwsManagedPrometheusScraperEksSource.cluster_arn` is now `containment_exempt`. The scraper reads the cluster's metrics; its collectors run on AWS-managed network interfaces in the subnets the same source block names, never as workloads inside the cluster. Until now the reference was placement by omission, so a scraper pointed at an EKS cluster would have been drawn inside the cluster it merely reads -- or, because it also names two subnets, inside whichever of the three candidates happened to sort last.

The containment-decision registry moves exactly one line from `contained` to `exempt`; nothing else moved.

## Why

Every other reference into an EKS cluster in the catalog is a resource that genuinely runs in the cluster (a node group, an add-on, a Fargate profile, an access entry, a Batch environment on EKS) and stays placement. The scraper is the one reader. On a diagram it now stands where its subnets place it, inside the VPC beside the cluster, with a line to the cluster it scrapes -- the verdict the Lambda's VPC subnets, the EventBridge pipe's task subnets, and the AgentCore private endpoints already carry.

## Test plan

- `buf lint` and `buf format -d` clean on the package.
- Go stubs regenerated with the pinned `protoc-gen-go v1.36.6`; only `spec.pb.go` changed.
- `go test ./shared/cloudresourcekind/...` green; the golden diff is the one line.