### PR TITLE
fix(catalog/azure): a Network Watcher flow log writes to the storage account it records into and never lives in it on a diagram

### DIFF
--- a/_changelog/2026-09/2026-09-09-193500-a-flow-log-writes-to-the-storage-account-it-records-into-and-never-lives-in-it-on-a-diagram.md
+++ b/_changelog/2026-09/2026-09-09-193500-a-flow-log-writes-to-the-storage-account-it-records-into-and-never-lives-in-it-on-a-diagram.md
@@ -1,0 +1,17 @@
+# A flow log writes to the storage account it records into and never lives in it on a diagram
+
+## What changed
+
+- **The Network Watcher flow log's storage account reference is containment-exempt.** `AzureNetworkWatcherFlowLogSpec.storage_account_id` names the storage account the flow-log files land in. The flow log itself is a Network Watcher resource that lives in the watcher's resource group (`NetworkWatcherRG` on most subscriptions) and records one network, subnet, or interface; it is never a thing inside the account. Until now the reference was placement by omission, so a flow log would have been drawn inside the storage account it merely writes to.
+- The containment-decision registry (`shared/cloudresourcekind/testdata/containment_decisions.txt`) moves exactly that one line from `contained` to `exempt`; nothing else in the registry moved.
+
+## Why
+
+`container_kind` says a kind is a box other resources nest inside, and `containment_exempt` says a reference into such a box is access, not placement. The storage account is a container because its containers, shares, queues, and tables are created into it; a flow log is created into a Network Watcher and writes files across the wire. The diagnostic setting's `storage_account_id` already carries the same exemption for the same reason -- a resource that delivers records to an account stands beside it with a line, the way a log delivery stands beside its bucket. The flow log now reads the same way.
+
+## How to check
+
+```bash
+go test ./shared/cloudresourcekind/... -run TestContainmentDecisions   # green; the golden carries the exempt line
+grep -n containment_exempt catalog/azure/azurenetworkwatcherflowlog/v1alpha1/spec.proto
+```

--- a/catalog/azure/azurenetworkwatcherflowlog/v1alpha1/spec.pb.go
+++ b/catalog/azure/azurenetworkwatcherflowlog/v1alpha1/spec.pb.go
@@ -75,7 +75,10 @@ type AzureNetworkWatcherFlowLogSpec struct {
 	// The storage account flow-log files land in -- references an
 	// AzureStorageAccount's ARM id. Creating the flow log writes a
 	// lifecycle-management rule on this account that OVERWRITES existing
-	// rules (see the spec note). Updatable in place.
+	// rules (see the spec note). Updatable in place. Containment-exempt: the
+	// flow log WRITES to the account and lives in its Network Watcher's
+	// resource group, so on a diagram it is drawn beside the account with a
+	// line to it, never inside it.
 	StorageAccountId *v1.StringValueOrRef `protobuf:"bytes,4,opt,name=storage_account_id,json=storageAccountId,proto3" json:"storage_account_id,omitempty"`
 	// Whether the flow log actively records. Unspecified applies true --
 	// a flow log exists to record; set false to pause collection while
@@ -373,14 +376,14 @@ var File_catalog_azure_azurenetworkwatcherflowlog_v1alpha1_spec_proto protorefle
 
 const file_catalog_azure_azurenetworkwatcherflowlog_v1alpha1_spec_proto_rawDesc = "" +
 	"\n" +
-	"<catalog/azure/azurenetworkwatcherflowlog/v1alpha1/spec.proto\x125dev.planton.azure.azurenetworkwatcherflowlog.v1alpha1\x1a\x1bbuf/validate/validate.proto\x1a&shared/foreignkey/v1/foreign_key.proto\x1a\x1cshared/options/options.proto\"\xd7\x0f\n" +
+	"<catalog/azure/azurenetworkwatcherflowlog/v1alpha1/spec.proto\x125dev.planton.azure.azurenetworkwatcherflowlog.v1alpha1\x1a\x1bbuf/validate/validate.proto\x1a&shared/foreignkey/v1/foreign_key.proto\x1a\x1cshared/options/options.proto\"\xdb\x0f\n" +
 	"\x1eAzureNetworkWatcherFlowLogSpec\x12\"\n" +
 	"\x06region\x18\x01 \x01(\tB\n" +
 	"\xbaH\a\xc8\x01\x01r\x02\x10\x01R\x06region\x12\xae\x02\n" +
 	"\x04name\x18\x02 \x01(\tB\x99\x02\xbaH\x95\x02\xba\x01\x8a\x02\n" +
 	"\x14flow_log_name_format\x12\xaa\x01Flow log names start with a letter or number, end with a letter, number, or underscore, and may contain alphanumerics, underscores, periods, and hyphens (1-80 characters)\x1aEthis == '' || this.matches('^[^\\\\W_]$|^[^\\\\W_][\\\\w.\\\\-]{0,78}[\\\\w]$')\xc8\x01\x01r\x02\x18PR\x04name\x12h\n" +
-	"\x12target_resource_id\x18\x03 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB\x06\xbaH\x03\xc8\x01\x01R\x10targetResourceId\x12\x92\x01\n" +
-	"\x12storage_account_id\x18\x04 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB0\xbaH\x03\xc8\x01\x01\x88\xd4a\xd9\x0f\x92\xd4a!status.outputs.storage_account_idR\x10storageAccountId\x12'\n" +
+	"\x12target_resource_id\x18\x03 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB\x06\xbaH\x03\xc8\x01\x01R\x10targetResourceId\x12\x96\x01\n" +
+	"\x12storage_account_id\x18\x04 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB4\xbaH\x03\xc8\x01\x01\x88\xd4a\xd9\x0f\x92\xd4a!status.outputs.storage_account_id\x98\xd4a\x01R\x10storageAccountId\x12'\n" +
 	"\aenabled\x18\x05 \x01(\bB\b\x8a\xa6\x1d\x04trueH\x00R\aenabled\x88\x01\x01\x12-\n" +
 	"\aversion\x18\x06 \x01(\x05B\x0e\xbaH\x06\x1a\x04\x18\x02(\x01\x8a\xa6\x1d\x011H\x01R\aversion\x88\x01\x01\x12\x93\x01\n" +
 	"\x10retention_policy\x18\a \x01(\v2`.dev.planton.azure.azurenetworkwatcherflowlog.v1alpha1.AzureNetworkWatcherFlowLogRetentionPolicyB\x06\xbaH\x03\xc8\x01\x01R\x0fretentionPolicy\x12\x8e\x01\n" +

--- a/catalog/azure/azurenetworkwatcherflowlog/v1alpha1/spec.proto
+++ b/catalog/azure/azurenetworkwatcherflowlog/v1alpha1/spec.proto
@@ -70,10 +70,14 @@ message AzureNetworkWatcherFlowLogSpec {
   // The storage account flow-log files land in -- references an
   // AzureStorageAccount's ARM id. Creating the flow log writes a
   // lifecycle-management rule on this account that OVERWRITES existing
-  // rules (see the spec note). Updatable in place.
+  // rules (see the spec note). Updatable in place. Containment-exempt: the
+  // flow log WRITES to the account and lives in its Network Watcher's
+  // resource group, so on a diagram it is drawn beside the account with a
+  // line to it, never inside it.
   dev.planton.shared.foreignkey.v1.StringValueOrRef storage_account_id = 4 [
     (buf.validate.field).required = true,
     (dev.planton.shared.foreignkey.v1.default_kind) = AzureStorageAccount,
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true,
     (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.storage_account_id"
   ];
 

--- a/shared/cloudresourcekind/testdata/containment_decisions.txt
+++ b/shared/cloudresourcekind/testdata/containment_decisions.txt
@@ -273,7 +273,6 @@ contained dev.planton.azure.azurenetworkinterface.v1alpha1.AzureNetworkInterface
 contained dev.planton.azure.azurenetworkinterface.v1alpha1.AzureNetworkInterfaceSpec.resource_group -> AzureResourceGroup
 contained dev.planton.azure.azurenetworksecuritygroup.v1alpha1.AzureNetworkSecurityGroupSpec.resource_group -> AzureResourceGroup
 contained dev.planton.azure.azurenetworkwatcherflowlog.v1alpha1.AzureNetworkWatcherFlowLogSpec.network_watcher_resource_group -> AzureResourceGroup
-contained dev.planton.azure.azurenetworkwatcherflowlog.v1alpha1.AzureNetworkWatcherFlowLogSpec.storage_account_id -> AzureStorageAccount
 contained dev.planton.azure.azureplantonrunner.v1alpha1.AzurePlantonRunnerSpec.container_app_environment_id -> AzureContainerAppEnvironment
 contained dev.planton.azure.azureplantonrunner.v1alpha1.AzurePlantonRunnerSpec.resource_group -> AzureResourceGroup
 contained dev.planton.azure.azurepointtositevpngateway.v1alpha1.AzurePointToSiteVpnGatewaySpec.resource_group -> AzureResourceGroup
@@ -716,6 +715,7 @@ exempt    dev.planton.azure.azuremonitordiagnosticsetting.v1alpha1.AzureMonitorD
 exempt    dev.planton.azure.azuremonitordiagnosticsetting.v1alpha1.AzureMonitorDiagnosticSettingSpec.storage_account_id -> AzureStorageAccount
 exempt    dev.planton.azure.azuremssqlserver.v1alpha1.AzureMssqlServerVirtualNetworkRule.subnet_id -> AzureSubnet
 exempt    dev.planton.azure.azuremysqlflexibleserver.v1alpha1.AzureMysqlFlexibleServerSpec.private_dns_zone_id -> AzurePrivateDnsZone
+exempt    dev.planton.azure.azurenetworkwatcherflowlog.v1alpha1.AzureNetworkWatcherFlowLogSpec.storage_account_id -> AzureStorageAccount
 exempt    dev.planton.azure.azurepostgresqlflexibleserver.v1alpha1.AzurePostgresqlFlexibleServerSpec.private_dns_zone_id -> AzurePrivateDnsZone
 exempt    dev.planton.azure.azureprivatednsresolver.v1alpha1.AzurePrivateDnsResolverSpec.virtual_network_id -> AzureVirtualNetwork
 exempt    dev.planton.azure.azureprivatednsresolvervirtualnetworklink.v1alpha1.AzurePrivateDnsResolverVirtualNetworkLinkSpec.virtual_network_id -> AzureVirtualNetwork


### PR DESCRIPTION
## What

`AzureNetworkWatcherFlowLogSpec.storage_account_id` is now `containment_exempt`. A flow log is a Network Watcher resource that lives in the watcher's resource group and records one network, subnet, or interface; the storage account is where its files land. Until now the reference was placement by omission, so a flow log pointed at a storage account would have been drawn inside the account it merely writes to.

The containment-decision registry moves exactly one line from `contained` to `exempt`; nothing else moved.

## Why

The storage account is a container because its containers, shares, queues, and tables are created into it. A flow log is created into a Network Watcher and writes files across the wire -- the same relationship the diagnostic setting's `storage_account_id` already carries as an exemption. On a diagram the flow log now stands where its Network Watcher's resource group places it, beside the account with a line to it, the way a log delivery stands beside its bucket.

## Test plan

- `buf lint` and `buf format -d` clean on the package.
- Go stubs regenerated with the pinned `protoc-gen-go v1.36.6`; only `spec.pb.go` changed (the comment and the option bytes).
- `go test ./shared/cloudresourcekind/...` green; the golden diff is the one line.