### PR TITLE
fix(catalog/azure): a Traffic Manager profile and a Front Door origin group are the rooms their endpoints and origins stand in on a diagram

### DIFF
--- a/_changelog/2026-09/2026-09-10-011500-a-traffic-manager-profile-and-a-front-door-origin-group-are-the-rooms-their-endpoints-and-origins-stand-in-on-a-diagram.md
+++ b/_changelog/2026-09/2026-09-10-011500-a-traffic-manager-profile-and-a-front-door-origin-group-are-the-rooms-their-endpoints-and-origins-stand-in-on-a-diagram.md
@@ -1,0 +1,20 @@
+# A Traffic Manager profile and a Front Door origin group are the rooms their endpoints and origins stand in on a diagram
+
+## What changed
+
+- **`AzureTrafficManagerProfile` and `AzureFrontDoorOriginGroup` are container kinds.** The kind metadata already said it in words -- "every endpoint is created inside a referenced profile" and "an origin is an ARM child of a referenced origin group", the same words the DNS record uses about its zone -- and now says it with `container_kind: true`, so the containment resolvers nest those kinds where Azure puts them: Traffic Manager endpoints inside the profile that steers traffic to them, Front Door origins inside the origin group that load-balances them (which in turn stands inside its Front Door profile).
+- **Three references that point AT one of those rooms are containment-exempt.** A nested Traffic Manager endpoint's `target_profile_id` names the child profile it forwards to; the endpoint lives in its own parent profile. A Front Door route's `origin_group_id` names the group that answers its requests; the route lives in its endpoint. A Front Door rule's route-configuration override names the group it redirects to; the rule set lives in its profile. Each is access, not placement, and had the container marks landed alone, all three would have become placement by omission -- a route drawn inside the origin group it forwards to, or torn between its endpoint and that group.
+- The containment-decision registry (`shared/cloudresourcekind/testdata/containment_decisions.txt`) gains exactly two `contained` lines (`AzureTrafficManagerEndpointSpec.profile_id`, `AzureFrontDoorOriginSpec.origin_group_id`) and three `exempt` lines (the references above). Nothing else in the registry moved: these five are every typed reference into either kind across the catalog.
+
+## Why
+
+`container_kind` says a kind is a box other resources nest inside; `containment_exempt` says a reference into such a box is access, not placement. Azure's own portal shows a Traffic Manager profile as a table of its endpoints and an origin group as a table of its origins, and ARM's resource paths nest them (`trafficmanagerprofiles/{p}/azureEndpoints/{e}`, `profiles/{p}/originGroups/{g}/origins/{o}`). Drawing the parent as a card and each child as a card beside it hides that shape; the marks let a diagram draw what Azure draws. The exemptions and the marks travel together because each is only truthful beside the other.
+
+## How to check
+
+```bash
+go test ./shared/cloudresourcekind/... -run TestContainmentDecisions   # green; the golden carries the two placements and the three exemptions
+grep -n -A8 'AzureTrafficManagerProfile = 2189' shared/cloudresourcekind/cloud_resource_kind.proto | grep container_kind
+grep -n -A8 'AzureFrontDoorOriginGroup = 2082' shared/cloudresourcekind/cloud_resource_kind.proto | grep container_kind
+grep -n containment_exempt catalog/azure/azuretrafficmanagerendpoint/v1alpha1/spec.proto catalog/azure/azurefrontdoorroute/v1alpha1/spec.proto catalog/azure/azurefrontdoorruleset/v1alpha1/spec.proto
+```

--- a/catalog/azure/azurefrontdoorroute/v1alpha1/spec.pb.go
+++ b/catalog/azure/azurefrontdoorroute/v1alpha1/spec.pb.go
@@ -232,7 +232,9 @@ type AzureFrontDoorRouteSpec struct {
 	// The origin group that answers requests matched by this route, by ARM
 	// ID. References an AzureFrontDoorOriginGroup's origin_group_id
 	// output. Updatable in place (repointing a route is how traffic moves
-	// between backend pools).
+	// between backend pools). The route lives in its endpoint and forwards
+	// TO the origin group, so the reference is access, not placement, on a
+	// diagram.
 	OriginGroupId *v1.StringValueOrRef `protobuf:"bytes,3,opt,name=origin_group_id,json=originGroupId,proto3" json:"origin_group_id,omitempty"`
 	// The origins this route depends on, by ARM ID -- each references an
 	// AzureFrontDoorOrigin's origin_id output. Azure never receives these
@@ -521,14 +523,14 @@ var File_catalog_azure_azurefrontdoorroute_v1alpha1_spec_proto protoreflect.File
 
 const file_catalog_azure_azurefrontdoorroute_v1alpha1_spec_proto_rawDesc = "" +
 	"\n" +
-	"5catalog/azure/azurefrontdoorroute/v1alpha1/spec.proto\x12.dev.planton.azure.azurefrontdoorroute.v1alpha1\x1a\x1bbuf/validate/validate.proto\x1a&shared/foreignkey/v1/foreign_key.proto\x1a\x1cshared/options/options.proto\"\xc5\x13\n" +
+	"5catalog/azure/azurefrontdoorroute/v1alpha1/spec.proto\x12.dev.planton.azure.azurefrontdoorroute.v1alpha1\x1a\x1bbuf/validate/validate.proto\x1a&shared/foreignkey/v1/foreign_key.proto\x1a\x1cshared/options/options.proto\"\xc9\x13\n" +
 	"\x17AzureFrontDoorRouteSpec\x12~\n" +
 	"\vendpoint_id\x18\x01 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB)\xbaH\x03\xc8\x01\x01\x88\xd4a\xa1\x10\x92\xd4a\x1astatus.outputs.endpoint_idR\n" +
 	"endpointId\x12\x84\x02\n" +
 	"\n" +
 	"route_name\x18\x02 \x01(\tB\xe4\x01\xbaH\xe0\x01\xba\x01\xd3\x01\n" +
-	"\x1cfront_door_route_name_format\x12wroute_name must be 2-90 characters, start and end with a letter or digit, and contain only letters, digits, and hyphens\x1a:this.matches('^[a-zA-Z0-9][a-zA-Z0-9-]{0,88}[a-zA-Z0-9]$')\xc8\x01\x01r\x04\x10\x02\x18ZR\trouteName\x12\x89\x01\n" +
-	"\x0forigin_group_id\x18\x03 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB-\xbaH\x03\xc8\x01\x01\x88\xd4a\xa2\x10\x92\xd4a\x1estatus.outputs.origin_group_idR\roriginGroupId\x12t\n" +
+	"\x1cfront_door_route_name_format\x12wroute_name must be 2-90 characters, start and end with a letter or digit, and contain only letters, digits, and hyphens\x1a:this.matches('^[a-zA-Z0-9][a-zA-Z0-9-]{0,88}[a-zA-Z0-9]$')\xc8\x01\x01r\x04\x10\x02\x18ZR\trouteName\x12\x8d\x01\n" +
+	"\x0forigin_group_id\x18\x03 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB1\xbaH\x03\xc8\x01\x01\x88\xd4a\xa2\x10\x92\xd4a\x1estatus.outputs.origin_group_id\x98\xd4a\x01R\roriginGroupId\x12t\n" +
 	"\n" +
 	"origin_ids\x18\x04 \x03(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB!\x88\xd4a\xa3\x10\x92\xd4a\x18status.outputs.origin_idR\toriginIds\x12y\n" +
 	"\frule_set_ids\x18\x05 \x03(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB#\x88\xd4a\xa5\x10\x92\xd4a\x1astatus.outputs.rule_set_idR\n" +

--- a/catalog/azure/azurefrontdoorroute/v1alpha1/spec.proto
+++ b/catalog/azure/azurefrontdoorroute/v1alpha1/spec.proto
@@ -51,10 +51,13 @@ message AzureFrontDoorRouteSpec {
   // The origin group that answers requests matched by this route, by ARM
   // ID. References an AzureFrontDoorOriginGroup's origin_group_id
   // output. Updatable in place (repointing a route is how traffic moves
-  // between backend pools).
+  // between backend pools). The route lives in its endpoint and forwards
+  // TO the origin group, so the reference is access, not placement, on a
+  // diagram.
   dev.planton.shared.foreignkey.v1.StringValueOrRef origin_group_id = 3 [
     (buf.validate.field).required = true,
     (dev.planton.shared.foreignkey.v1.default_kind) = AzureFrontDoorOriginGroup,
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true,
     (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.origin_group_id"
   ];
 

--- a/catalog/azure/azurefrontdoorruleset/v1alpha1/spec.pb.go
+++ b/catalog/azure/azurefrontdoorruleset/v1alpha1/spec.pb.go
@@ -2652,6 +2652,8 @@ type AzureFrontDoorRuleRouteConfigurationOverrideAction struct {
 	// own, by ARM ID. References an AzureFrontDoorOriginGroup's
 	// origin_group_id output. When set, forwarding_protocol must be
 	// chosen too; when unset, the route's own origin group keeps serving.
+	// The rule set lives in its profile and steers TO the origin group, so
+	// the reference is access, not placement, on a diagram.
 	OriginGroupId *v1.StringValueOrRef `protobuf:"bytes,1,opt,name=origin_group_id,json=originGroupId,proto3" json:"origin_group_id,omitempty"`
 	// The protocol toward the overriding origin group. Required when
 	// origin_group_id is set; must be left unspecified otherwise (it
@@ -2982,9 +2984,9 @@ const file_catalog_azure_azurefrontdoorruleset_v1alpha1_spec_proto_rawDesc = "" 
 	"\vheader_name\x18\x02 \x01(\tB\x06\xbaH\x03\xc8\x01\x01R\n" +
 	"headerName\x12\x14\n" +
 	"\x05value\x18\x03 \x01(\tR\x05value:\xc8\x01\xbaH\xc4\x01\x1a\xc1\x01\n" +
-	"\x1efront_door_header_action_value\x12`value is required when header_action is APPEND or OVERWRITE, and must be empty when it is DELETE\x1a=this.header_action == 3 ? this.value == '' : this.value != ''\"\x95\x15\n" +
-	"2AzureFrontDoorRuleRouteConfigurationOverrideAction\x12\x83\x01\n" +
-	"\x0forigin_group_id\x18\x01 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB'\x88\xd4a\xa2\x10\x92\xd4a\x1estatus.outputs.origin_group_idR\roriginGroupId\x12\x91\x01\n" +
+	"\x1efront_door_header_action_value\x12`value is required when header_action is APPEND or OVERWRITE, and must be empty when it is DELETE\x1a=this.header_action == 3 ? this.value == '' : this.value != ''\"\x99\x15\n" +
+	"2AzureFrontDoorRuleRouteConfigurationOverrideAction\x12\x87\x01\n" +
+	"\x0forigin_group_id\x18\x01 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB+\x88\xd4a\xa2\x10\x92\xd4a\x1estatus.outputs.origin_group_id\x98\xd4a\x01R\roriginGroupId\x12\x91\x01\n" +
 	"\x13forwarding_protocol\x18\x02 \x01(\x0e2V.dev.planton.azure.azurefrontdoorruleset.v1alpha1.AzureFrontDoorRuleForwardingProtocolB\b\xbaH\x05\x82\x01\x02\x10\x01R\x12forwardingProtocol\x12\x84\x01\n" +
 	"\x0ecache_behavior\x18\x03 \x01(\x0e2Q.dev.planton.azure.azurefrontdoorruleset.v1alpha1.AzureFrontDoorRuleCacheBehaviorB\n" +
 	"\xbaH\a\x82\x01\x04\x10\x01 \x00R\rcacheBehavior\x12\xbe\x02\n" +

--- a/catalog/azure/azurefrontdoorruleset/v1alpha1/spec.proto
+++ b/catalog/azure/azurefrontdoorruleset/v1alpha1/spec.proto
@@ -1188,8 +1188,11 @@ message AzureFrontDoorRuleRouteConfigurationOverrideAction {
   // own, by ARM ID. References an AzureFrontDoorOriginGroup's
   // origin_group_id output. When set, forwarding_protocol must be
   // chosen too; when unset, the route's own origin group keeps serving.
+  // The rule set lives in its profile and steers TO the origin group, so
+  // the reference is access, not placement, on a diagram.
   dev.planton.shared.foreignkey.v1.StringValueOrRef origin_group_id = 1 [
     (dev.planton.shared.foreignkey.v1.default_kind) = AzureFrontDoorOriginGroup,
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true,
     (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.origin_group_id"
   ];
 

--- a/catalog/azure/azuretrafficmanagerendpoint/v1alpha1/spec.pb.go
+++ b/catalog/azure/azuretrafficmanagerendpoint/v1alpha1/spec.pb.go
@@ -356,7 +356,9 @@ type AzureTrafficManagerNestedEndpoint struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The CHILD profile's ARM resource ID -- defaults to referencing an
 	// AzureTrafficManagerProfile's traffic_manager_profile_id output.
-	// Retargeting updates the endpoint in place.
+	// Retargeting updates the endpoint in place. The endpoint lives in its
+	// own parent profile (profile_id) and merely points at this one, so the
+	// reference is access, not placement, on a diagram.
 	TargetProfileId *v1.StringValueOrRef `protobuf:"bytes,1,opt,name=target_profile_id,json=targetProfileId,proto3" json:"target_profile_id,omitempty"`
 	// The minimum number of healthy endpoints the child profile must
 	// hold for THIS endpoint to count as healthy (at least 1). Updatable
@@ -603,9 +605,9 @@ const file_catalog_azure_azuretrafficmanagerendpoint_v1alpha1_spec_proto_rawDesc
 	"\x06target\x18\x01 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB\x06\xbaH\x03\xc8\x01\x01R\x06target\x12+\n" +
 	"\x11endpoint_location\x18\x02 \x01(\tR\x10endpointLocation\x12@\n" +
 	"\x14always_serve_enabled\x18\x03 \x01(\bB\t\x8a\xa6\x1d\x05falseH\x00R\x12alwaysServeEnabled\x88\x01\x01B\x17\n" +
-	"\x15_always_serve_enabled\"\xe4\x04\n" +
-	"!AzureTrafficManagerNestedEndpoint\x12\x98\x01\n" +
-	"\x11target_profile_id\x18\x01 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB8\xbaH\x03\xc8\x01\x01\x88\xd4a\x8d\x11\x92\xd4a)status.outputs.traffic_manager_profile_idR\x0ftargetProfileId\x12G\n" +
+	"\x15_always_serve_enabled\"\xe8\x04\n" +
+	"!AzureTrafficManagerNestedEndpoint\x12\x9c\x01\n" +
+	"\x11target_profile_id\x18\x01 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB<\xbaH\x03\xc8\x01\x01\x88\xd4a\x8d\x11\x92\xd4a)status.outputs.traffic_manager_profile_id\x98\xd4a\x01R\x0ftargetProfileId\x12G\n" +
 	"\x17minimum_child_endpoints\x18\x02 \x01(\x05B\n" +
 	"\xbaH\a\xc8\x01\x01\x1a\x02(\x01H\x00R\x15minimumChildEndpoints\x88\x01\x01\x12^\n" +
 	"%minimum_required_child_endpoints_ipv4\x18\x03 \x01(\x05B\a\xbaH\x04\x1a\x02(\x00H\x01R!minimumRequiredChildEndpointsIpv4\x88\x01\x01\x12^\n" +

--- a/catalog/azure/azuretrafficmanagerendpoint/v1alpha1/spec.proto
+++ b/catalog/azure/azuretrafficmanagerendpoint/v1alpha1/spec.proto
@@ -164,10 +164,13 @@ message AzureTrafficManagerExternalEndpoint {
 message AzureTrafficManagerNestedEndpoint {
   // The CHILD profile's ARM resource ID -- defaults to referencing an
   // AzureTrafficManagerProfile's traffic_manager_profile_id output.
-  // Retargeting updates the endpoint in place.
+  // Retargeting updates the endpoint in place. The endpoint lives in its
+  // own parent profile (profile_id) and merely points at this one, so the
+  // reference is access, not placement, on a diagram.
   dev.planton.shared.foreignkey.v1.StringValueOrRef target_profile_id = 1 [
     (buf.validate.field).required = true,
     (dev.planton.shared.foreignkey.v1.default_kind) = AzureTrafficManagerProfile,
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true,
     (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.traffic_manager_profile_id"
   ];
 

--- a/shared/cloudresourcekind/cloud_resource_kind.pb.go
+++ b/shared/cloudresourcekind/cloud_resource_kind.pb.go
@@ -1144,7 +1144,12 @@ const (
 	// through the profile's own prerequisite declaration.)
 	CloudResourceKind_AzureFrontDoorEndpoint CloudResourceKind = 2081
 	// AzureFrontDoorProfile is a prerequisite because an origin group is an
-	// ARM child of a referenced profile.
+	// ARM child of a referenced profile. A container kind: every origin is an
+	// ARM child of its origin group, so on a diagram the origins stand inside
+	// the group that load-balances them (the profile's room holds the group).
+	// A route or a rule that forwards TO an origin group lives in its endpoint
+	// or its rule set, never in the group, and those references say so with
+	// containment_exempt.
 	CloudResourceKind_AzureFrontDoorOriginGroup CloudResourceKind = 2082
 	// AzureFrontDoorOriginGroup is a prerequisite because an origin is an
 	// ARM child of a referenced origin group (the profile and resource
@@ -1467,7 +1472,11 @@ const (
 	// AzureResourceGroup is a prerequisite because a Traffic Manager
 	// profile is created inside a referenced resource group (the profile
 	// itself is a global service -- the group only holds its metadata
-	// record).
+	// record). A container kind: every endpoint is an ARM child of its
+	// profile, so on a diagram the endpoints stand inside the profile that
+	// steers traffic to them. A nested endpoint that points AT another
+	// profile lives in its own parent profile, never in the one it targets,
+	// and that reference says so with containment_exempt.
 	CloudResourceKind_AzureTrafficManagerProfile CloudResourceKind = 2189
 	// AzureTrafficManagerProfile is a prerequisite because every
 	// endpoint is created inside a referenced profile -- it is the
@@ -4196,7 +4205,7 @@ const file_shared_cloudresourcekind_cloud_resource_kind_proto_rawDesc = "" +
 	"\x1cKubernetesManifestProjection\x12\x1f\n" +
 	"\vapi_version\x18\x01 \x01(\tR\n" +
 	"apiVersion\x12\x12\n" +
-	"\x04kind\x18\x02 \x01(\tR\x04kind*\x96\xdb\x02\n" +
+	"\x04kind\x18\x02 \x01(\tR\x04kind*\x9a\xdb\x02\n" +
 	"\x11CloudResourceKind\x12\x0f\n" +
 	"\vunspecified\x10\x00\x12b\n" +
 	"\x18TestCloudResourceGeneric\x10\x01\x1aD\xa2\xf7\x04@\b\x01\x12\bv1alpha2\"\x04tcrgJ,\n" +
@@ -4526,8 +4535,8 @@ const file_shared_cloudresourcekind_cloud_resource_kind_proto_rawDesc = "" +
 	"\x1aAzureEventHubConsumerGroup\x10\x9e\x10\x1a\x1b\xa2\xf7\x04\x17\b\r\x12\bv1alpha1\"\x06azehcgP\xd1\x01\x12B\n" +
 	"\x1eAzureEventHubAuthorizationRule\x10\x9f\x10\x1a\x1d\xa2\xf7\x04\x19\b\r\x12\bv1alpha1\"\bazehauthP\xd1\x01\x12;\n" +
 	"\x15AzureFrontDoorProfile\x10\xa0\x10\x1a\x1f\xa2\xf7\x04\x1b\b\r\x12\bv1alpha1\"\x04azfd0\x01:\x02\xd0\x0fP\xcd\x01\x12=\n" +
-	"\x16AzureFrontDoorEndpoint\x10\xa1\x10\x1a \xa2\xf7\x04\x1c\b\r\x12\bv1alpha1\"\x05azfde0\x01:\x02\xa0\x10P\xcd\x01\x12?\n" +
-	"\x19AzureFrontDoorOriginGroup\x10\xa2\x10\x1a\x1f\xa2\xf7\x04\x1b\b\r\x12\bv1alpha1\"\x06azfdog:\x02\xa0\x10P\xcd\x01\x129\n" +
+	"\x16AzureFrontDoorEndpoint\x10\xa1\x10\x1a \xa2\xf7\x04\x1c\b\r\x12\bv1alpha1\"\x05azfde0\x01:\x02\xa0\x10P\xcd\x01\x12A\n" +
+	"\x19AzureFrontDoorOriginGroup\x10\xa2\x10\x1a!\xa2\xf7\x04\x1d\b\r\x12\bv1alpha1\"\x06azfdog0\x01:\x02\xa0\x10P\xcd\x01\x129\n" +
 	"\x14AzureFrontDoorOrigin\x10\xa3\x10\x1a\x1e\xa2\xf7\x04\x1a\b\r\x12\bv1alpha1\"\x05azfdo:\x02\xa2\x10P\xcd\x01\x12;\n" +
 	"\x13AzureFrontDoorRoute\x10\xa4\x10\x1a!\xa2\xf7\x04\x1d\b\r\x12\bv1alpha1\"\x06azfdrt:\x04\xa1\x10\xa3\x10P\xcd\x01\x12;\n" +
 	"\x15AzureFrontDoorRuleSet\x10\xa5\x10\x1a\x1f\xa2\xf7\x04\x1b\b\r\x12\bv1alpha1\"\x06azfdrs:\x02\xa0\x10P\xcd\x01\x12@\n" +
@@ -4606,8 +4615,8 @@ const file_shared_cloudresourcekind_cloud_resource_kind_proto_rawDesc = "" +
 	"\x1aAzureNetworkWatcherFlowLog\x10\x89\x11\x1a\"\xa2\xf7\x04\x1e\b\r\x12\bv1alpha1\"\aazfwlog:\x04\xd6\x0f\xd9\x0fP\xcd\x01\x12@\n" +
 	"\x17AzurePrivateDnsResolver\x10\x8a\x11\x1a\"\xa2\xf7\x04\x1e\b\r\x12\bv1alpha1\"\aazpdnsr:\x04\xd6\x0f\xdb\x0fP\xcd\x01\x12Q\n" +
 	"(AzurePrivateDnsResolverForwardingRuleset\x10\x8b\x11\x1a\"\xa2\xf7\x04\x1e\b\r\x12\bv1alpha1\"\tazpdnsfrs:\x02\x8a\x11P\xcd\x01\x12>\n" +
-	"\x15AzurePrivateDnsRecord\x10\x8c\x11\x1a\"\xa2\xf7\x04\x1e\b\r\x12\bv1alpha1\"\tazpdnsrec:\x02\xdf\x0fP\xcd\x01\x12B\n" +
-	"\x1aAzureTrafficManagerProfile\x10\x8d\x11\x1a!\xa2\xf7\x04\x1d\b\r\x12\bv1alpha1\"\baztmprof:\x02\xd0\x0fP\xcd\x01\x12A\n" +
+	"\x15AzurePrivateDnsRecord\x10\x8c\x11\x1a\"\xa2\xf7\x04\x1e\b\r\x12\bv1alpha1\"\tazpdnsrec:\x02\xdf\x0fP\xcd\x01\x12D\n" +
+	"\x1aAzureTrafficManagerProfile\x10\x8d\x11\x1a#\xa2\xf7\x04\x1f\b\r\x12\bv1alpha1\"\baztmprof0\x01:\x02\xd0\x0fP\xcd\x01\x12A\n" +
 	"\x1bAzureTrafficManagerEndpoint\x10\x8e\x11\x1a\x1f\xa2\xf7\x04\x1b\b\r\x12\bv1alpha1\"\x06aztmep:\x02\x8d\x11P\xcd\x01\x12G\n" +
 	"\x1cAzureMonitorAutoscaleSetting\x10\x8f\x11\x1a$\xa2\xf7\x04 \b\r\x12\bv1alpha1\"\vazautoscale:\x02\xd0\x0fP\xd3\x01\x12E\n" +
 	"\x1eAzureMonitorDataCollectionRule\x10\x90\x11\x1a \xa2\xf7\x04\x1c\b\r\x12\bv1alpha1\"\x05azdcr:\x04\xd0\x0f\x82\x10P\xd3\x01\x128\n" +

--- a/shared/cloudresourcekind/cloud_resource_kind.proto
+++ b/shared/cloudresourcekind/cloud_resource_kind.proto
@@ -3143,12 +3143,18 @@ enum CloudResourceKind {
     service_group: azure_networking
   }];
   // AzureFrontDoorProfile is a prerequisite because an origin group is an
-  // ARM child of a referenced profile.
+  // ARM child of a referenced profile. A container kind: every origin is an
+  // ARM child of its origin group, so on a diagram the origins stand inside
+  // the group that load-balances them (the profile's room holds the group).
+  // A route or a rule that forwards TO an origin group lives in its endpoint
+  // or its rule set, never in the group, and those references say so with
+  // containment_exempt.
   AzureFrontDoorOriginGroup = 2082 [(kind_meta) = {
     provider: azure
     version: "v1alpha1"
     id_prefix: "azfdog"
     prerequisites: [AzureFrontDoorProfile]
+    container_kind: true
     service_group: azure_networking
   }];
   // AzureFrontDoorOriginGroup is a prerequisite because an origin is an
@@ -4019,12 +4025,17 @@ enum CloudResourceKind {
   // AzureResourceGroup is a prerequisite because a Traffic Manager
   // profile is created inside a referenced resource group (the profile
   // itself is a global service -- the group only holds its metadata
-  // record).
+  // record). A container kind: every endpoint is an ARM child of its
+  // profile, so on a diagram the endpoints stand inside the profile that
+  // steers traffic to them. A nested endpoint that points AT another
+  // profile lives in its own parent profile, never in the one it targets,
+  // and that reference says so with containment_exempt.
   AzureTrafficManagerProfile = 2189 [(kind_meta) = {
     provider: azure
     version: "v1alpha1"
     id_prefix: "aztmprof"
     prerequisites: [AzureResourceGroup]
+    container_kind: true
     service_group: azure_networking
   }];
   // AzureTrafficManagerProfile is a prerequisite because every

--- a/shared/cloudresourcekind/testdata/containment_decisions.txt
+++ b/shared/cloudresourcekind/testdata/containment_decisions.txt
@@ -223,6 +223,7 @@ contained dev.planton.azure.azurefirewallpolicy.v1alpha1.AzureFirewallPolicySpec
 contained dev.planton.azure.azurefrontdoorcustomdomain.v1alpha1.AzureFrontDoorCustomDomainSpec.profile_id -> AzureFrontDoorProfile
 contained dev.planton.azure.azurefrontdoorendpoint.v1alpha1.AzureFrontDoorEndpointSpec.profile_id -> AzureFrontDoorProfile
 contained dev.planton.azure.azurefrontdoorfirewallpolicy.v1alpha1.AzureFrontDoorFirewallPolicySpec.resource_group -> AzureResourceGroup
+contained dev.planton.azure.azurefrontdoororigin.v1alpha1.AzureFrontDoorOriginSpec.origin_group_id -> AzureFrontDoorOriginGroup
 contained dev.planton.azure.azurefrontdoororigingroup.v1alpha1.AzureFrontDoorOriginGroupSpec.profile_id -> AzureFrontDoorProfile
 contained dev.planton.azure.azurefrontdoorprofile.v1alpha1.AzureFrontDoorProfileSpec.resource_group -> AzureResourceGroup
 contained dev.planton.azure.azurefrontdoorroute.v1alpha1.AzureFrontDoorRouteSpec.endpoint_id -> AzureFrontDoorEndpoint
@@ -317,6 +318,7 @@ contained dev.planton.azure.azurestoragequeue.v1alpha1.AzureStorageQueueSpec.sto
 contained dev.planton.azure.azurestorageshare.v1alpha1.AzureStorageShareSpec.storage_account_id -> AzureStorageAccount
 contained dev.planton.azure.azurestoragetable.v1alpha1.AzureStorageTableSpec.storage_account_id -> AzureStorageAccount
 contained dev.planton.azure.azuresubnet.v1alpha1.AzureSubnetSpec.virtual_network_id -> AzureVirtualNetwork
+contained dev.planton.azure.azuretrafficmanagerendpoint.v1alpha1.AzureTrafficManagerEndpointSpec.profile_id -> AzureTrafficManagerProfile
 contained dev.planton.azure.azuretrafficmanagerprofile.v1alpha1.AzureTrafficManagerProfileSpec.resource_group -> AzureResourceGroup
 contained dev.planton.azure.azureuserassignedidentity.v1alpha1.AzureUserAssignedIdentitySpec.resource_group -> AzureResourceGroup
 contained dev.planton.azure.azurevirtualhub.v1alpha1.AzureVirtualHubSpec.resource_group -> AzureResourceGroup
@@ -693,6 +695,8 @@ exempt    dev.planton.azure.azureeventhubdisasterrecoveryconfig.v1alpha1.AzureEv
 exempt    dev.planton.azure.azureeventhubnamespace.v1alpha1.AzureEventHubNamespaceVirtualNetworkRule.subnet_id -> AzureSubnet
 exempt    dev.planton.azure.azurefederatedidentitycredential.v1alpha1.AzureFederatedIdentityCredentialSpec.issuer -> AzureAksCluster
 exempt    dev.planton.azure.azurefrontdoorcustomdomain.v1alpha1.AzureFrontDoorCustomDomainSpec.dns_zone_id -> AzureDnsZone
+exempt    dev.planton.azure.azurefrontdoorroute.v1alpha1.AzureFrontDoorRouteSpec.origin_group_id -> AzureFrontDoorOriginGroup
+exempt    dev.planton.azure.azurefrontdoorruleset.v1alpha1.AzureFrontDoorRuleRouteConfigurationOverrideAction.origin_group_id -> AzureFrontDoorOriginGroup
 exempt    dev.planton.azure.azurefrontdoorsecuritypolicy.v1alpha1.AzureFrontDoorSecurityPolicySpec.domain_ids -> AzureFrontDoorEndpoint
 exempt    dev.planton.azure.azurefunctionapp.v1alpha1.AzureFunctionAppIpRestriction.virtual_network_subnet_id -> AzureSubnet
 exempt    dev.planton.azure.azurefunctionapp.v1alpha1.AzureFunctionAppIpRestrictionHeaders.x_azure_fdid -> AzureFrontDoorProfile
@@ -726,6 +730,7 @@ exempt    dev.planton.azure.azureservicebusnamespace.v1alpha1.AzureServiceBusNam
 exempt    dev.planton.azure.azurestorageaccount.v1alpha1.AzureStorageAccountNetworkRules.virtual_network_subnet_ids -> AzureSubnet
 exempt    dev.planton.azure.azurestorageobjectreplication.v1alpha1.AzureStorageObjectReplicationSpec.destination_storage_account_id -> AzureStorageAccount
 exempt    dev.planton.azure.azurestorageobjectreplication.v1alpha1.AzureStorageObjectReplicationSpec.source_storage_account_id -> AzureStorageAccount
+exempt    dev.planton.azure.azuretrafficmanagerendpoint.v1alpha1.AzureTrafficManagerNestedEndpoint.target_profile_id -> AzureTrafficManagerProfile
 exempt    dev.planton.azure.azurevirtualmachine.v1alpha1.AzureVirtualMachineSecret.key_vault_id -> AzureKeyVault
 exempt    dev.planton.azure.azurevirtualmachinescaleset.v1alpha1.AzureVirtualMachineScaleSetExtensionProtectedSettingsFromKeyVault.source_vault_id -> AzureKeyVault
 exempt    dev.planton.azure.azurevirtualmachinescaleset.v1alpha1.AzureVirtualMachineScaleSetSecret.key_vault_id -> AzureKeyVault


### PR DESCRIPTION
## What changed

- **`AzureTrafficManagerProfile` and `AzureFrontDoorOriginGroup` are container kinds.** The kind metadata already said it in words -- "every endpoint is created inside a referenced profile" and "an origin is an ARM child of a referenced origin group", the same words the DNS record uses about its zone -- and now says it with `container_kind: true`, so the containment resolvers nest Traffic Manager endpoints inside the profile that steers traffic to them, and Front Door origins inside the origin group that load-balances them (which stands inside its Front Door profile).
- **Three references that point AT one of those rooms are containment-exempt**, because each is only truthful beside the marks: a nested Traffic Manager endpoint's `target_profile_id` (the endpoint lives in its own parent profile), a Front Door route's `origin_group_id` (the route lives in its endpoint and forwards TO the group), and a Front Door rule's route-configuration override `origin_group_id` (the rule set lives in its profile). Had the marks landed alone, all three would have become placement by omission.
- The containment-decision registry gains exactly two `contained` lines and three `exempt` lines -- every typed reference into either kind across the catalog. Nothing else moved.
- Go stubs regenerated with the pinned `protoc-gen-go v1.36.6` (comments and option bytes only); `buf lint` and `buf format -d` clean.

## Why

Azure's own portal shows a Traffic Manager profile as a table of its endpoints and an origin group as a table of its origins, and ARM's resource paths nest them (`trafficmanagerprofiles/{p}/azureEndpoints/{e}`, `profiles/{p}/originGroups/{g}/origins/{o}`). Drawing the parent as a card with each child as a card beside it hides that shape; the marks let a diagram draw what Azure draws. The exemptions and the marks travel together because each is only truthful beside the other.

## How to check

```bash
go test ./shared/cloudresourcekind/...   # green; the golden carries the two placements and the three exemptions
grep -n containment_exempt catalog/azure/azuretrafficmanagerendpoint/v1alpha1/spec.proto catalog/azure/azurefrontdoorroute/v1alpha1/spec.proto catalog/azure/azurefrontdoorruleset/v1alpha1/spec.proto
```
