### PR TITLE
fix(catalog/azure): a snapshot and an image version read the storage account and vault they name, and a Compute Gallery is the room its image definitions live in

### DIFF
--- a/_changelog/2026-09/2026-09-10-081500-a-snapshot-and-an-image-version-read-the-account-and-vault-they-name-and-a-compute-gallery-is-the-room-its-images-live-in.md
+++ b/_changelog/2026-09/2026-09-10-081500-a-snapshot-and-an-image-version-read-the-account-and-vault-they-name-and-a-compute-gallery-is-the-room-its-images-live-in.md
@@ -1,0 +1,19 @@
+# A snapshot and an image version read the account and vault they name, and a Compute Gallery is the room its images live in
+
+## What changed
+
+- **Four references in the Azure compute family are containment-exempt.** A disk snapshot imported from a VHD names the storage account holding the blob (`AzureDiskSnapshotSpec.storage_account_id`); a snapshot carrying legacy Azure Disk Encryption settings names the Key Vault holding its disk-encryption secret and its key-encryption key (`AzureDiskSnapshotDiskEncryptionKey.source_vault_id`, `AzureDiskSnapshotKeyEncryptionKey.source_vault_id`); a gallery image version built from a page blob names the storage account holding it (`AzureComputeGalleryImageVersion.storage_account_id`). Each of those resources READS out of the account or vault and lives in its own resource group (or its gallery), so on a diagram the reference is access, not placement -- the same reasoning a Network Watcher flow log's storage account and a virtual machine's Key Vault secrets already carry.
+- **`AzureComputeGallery` is a container kind.** The kind metadata already said it in words -- "image definitions live inside it" -- and ARM nests them (`{gallery_id}/images/{name}`); it now says it with `container_kind: true`, so the containment resolvers nest every image definition inside the library that publishes it. The image ids a VM, a scale set, or a disk boots from are plain strings and never place anything inside the gallery, so no exemption needs to travel with the mark.
+- The containment-decision registry (`shared/cloudresourcekind/testdata/containment_decisions.txt`) moves exactly four lines from `contained` to `exempt` and gains exactly one `contained` line (`AzureComputeGalleryImageSpec.gallery_name`, the only typed reference into a gallery across the catalog). Nothing else moved.
+
+## Why
+
+`containment_exempt` says a reference into a container is access, not placement; `container_kind` says a kind is a box other resources nest inside. Without the exemptions, a snapshot restored from a customer's VHD would be drawn inside the storage account it was read from, and a snapshot with disk-encryption settings inside the vault its key sits in -- a backup artifact drawn as a resident of what it merely consulted. Without the mark, a gallery and its image definitions draw as peer cards joined by lines, hiding the library shape Azure's own portal shows.
+
+## How to check
+
+```bash
+go test ./shared/cloudresourcekind/... -run TestContainmentDecisions   # green; the golden carries the four exemptions and the gallery placement
+grep -n -A8 'AzureComputeGallery = 2205' shared/cloudresourcekind/cloud_resource_kind.proto | grep container_kind
+grep -n containment_exempt catalog/azure/azuredisksnapshot/v1alpha1/spec.proto catalog/azure/azurecomputegalleryimage/v1alpha1/spec.proto
+```

--- a/catalog/azure/azurecomputegalleryimage/v1alpha1/spec.pb.go
+++ b/catalog/azure/azurecomputegalleryimage/v1alpha1/spec.pb.go
@@ -574,7 +574,9 @@ type AzureComputeGalleryImageVersion struct {
 	BlobUri string `protobuf:"bytes,3,opt,name=blob_uri,json=blobUri,proto3" json:"blob_uri,omitempty"`
 	// The storage account holding blob_uri. Required with blob_uri,
 	// forbidden otherwise. Can be a literal ARM ID or a reference to an
-	// AzureStorageAccount output.
+	// AzureStorageAccount output. The version is BUILT from the blob and
+	// lives in its gallery, so the reference is access, not placement, on a
+	// diagram.
 	//
 	// **ForceNew**: changing this destroys and recreates the version.
 	StorageAccountId *v1.StringValueOrRef `protobuf:"bytes,4,opt,name=storage_account_id,json=storageAccountId,proto3" json:"storage_account_id,omitempty"`
@@ -890,14 +892,14 @@ const file_catalog_azure_azurecomputegalleryimage_v1alpha1_spec_proto_rawDesc = 
 	"\x04name\x18\x01 \x01(\tB\n" +
 	"\xbaH\a\xc8\x01\x01r\x02\x10\x01R\x04name\x12\x1c\n" +
 	"\tpublisher\x18\x02 \x01(\tR\tpublisher\x12\x18\n" +
-	"\aproduct\x18\x03 \x01(\tR\aproduct\"\xec\x12\n" +
+	"\aproduct\x18\x03 \x01(\tR\aproduct\"\xf0\x12\n" +
 	"\x1fAzureComputeGalleryImageVersion\x12\x94\x02\n" +
 	"\x04name\x18\x01 \x01(\tB\xff\x01\xbaH\xfb\x01\xba\x01\xf4\x01\n" +
 	"!gallery_image_version_name_format\x12jVersion names are three dot-separated numeric segments (e.g. \"1.2.0\"), or the literal \"latest\" or \"recent\"\x1acthis.matches('^([0-9]{1,10}\\\\.[0-9]{1,10}\\\\.[0-9]{1,10})$') || this == 'latest' || this == 'recent'\xc8\x01\x01R\x04name\x12\x91\x01\n" +
 	"\x0etarget_regions\x18\x02 \x03(\v2`.dev.planton.azure.azurecomputegalleryimage.v1alpha1.AzureComputeGalleryImageVersionTargetRegionB\b\xbaH\x05\x92\x01\x02\b\x01R\rtargetRegions\x12\xbb\x01\n" +
 	"\bblob_uri\x18\x03 \x01(\tB\x9f\x01\xbaH\x9b\x01\xba\x01\x97\x01\n" +
-	"%gallery_image_version_blob_uri_scheme\x12%blob_uri must be an http or https URL\x1aGthis == '' || this.startsWith('http://') || this.startsWith('https://')R\ablobUri\x12\x8c\x01\n" +
-	"\x12storage_account_id\x18\x04 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB*\x88\xd4a\xd9\x0f\x92\xd4a!status.outputs.storage_account_idR\x10storageAccountId\x12\x86\x01\n" +
+	"%gallery_image_version_blob_uri_scheme\x12%blob_uri must be an http or https URL\x1aGthis == '' || this.startsWith('http://') || this.startsWith('https://')R\ablobUri\x12\x90\x01\n" +
+	"\x12storage_account_id\x18\x04 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB.\x88\xd4a\xd9\x0f\x92\xd4a!status.outputs.storage_account_id\x98\xd4a\x01R\x10storageAccountId\x12\x86\x01\n" +
 	"\x13os_disk_snapshot_id\x18\x05 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB#\x88\xd4a\xa0\x11\x92\xd4a\x1astatus.outputs.snapshot_idR\x10osDiskSnapshotId\x12\\\n" +
 	"\x10managed_image_id\x18\x06 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefR\x0emanagedImageId\x12A\n" +
 	"\x10replication_mode\x18\a \x01(\tB\x16\xbaH\x13r\x11R\x00R\x04FullR\aShallowR\x0freplicationMode\x12.\n" +

--- a/catalog/azure/azurecomputegalleryimage/v1alpha1/spec.proto
+++ b/catalog/azure/azurecomputegalleryimage/v1alpha1/spec.proto
@@ -369,11 +369,14 @@ message AzureComputeGalleryImageVersion {
 
   // The storage account holding blob_uri. Required with blob_uri,
   // forbidden otherwise. Can be a literal ARM ID or a reference to an
-  // AzureStorageAccount output.
+  // AzureStorageAccount output. The version is BUILT from the blob and
+  // lives in its gallery, so the reference is access, not placement, on a
+  // diagram.
   //
   // **ForceNew**: changing this destroys and recreates the version.
   dev.planton.shared.foreignkey.v1.StringValueOrRef storage_account_id = 4 [
     (dev.planton.shared.foreignkey.v1.default_kind) = AzureStorageAccount,
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true,
     (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.storage_account_id"
   ];
 

--- a/catalog/azure/azuredisksnapshot/v1alpha1/spec.pb.go
+++ b/catalog/azure/azuredisksnapshot/v1alpha1/spec.pb.go
@@ -82,7 +82,9 @@ type AzureDiskSnapshotSpec struct {
 	SourceUri string `protobuf:"bytes,6,opt,name=source_uri,json=sourceUri,proto3" json:"source_uri,omitempty"`
 	// The storage account holding source_uri (the read grant for
 	// "Import"). Can be a literal ARM ID or a reference to an
-	// AzureStorageAccount output.
+	// AzureStorageAccount output. The snapshot READS the VHD out of the
+	// account and lives in its own resource group, so the reference is
+	// access, not placement, on a diagram.
 	//
 	// **ForceNew**: changing this destroys and recreates the snapshot.
 	StorageAccountId *v1.StringValueOrRef `protobuf:"bytes,7,opt,name=storage_account_id,json=storageAccountId,proto3" json:"storage_account_id,omitempty"`
@@ -319,7 +321,9 @@ type AzureDiskSnapshotDiskEncryptionKey struct {
 	// The secret's URL (the Key Vault secret identifier).
 	SecretUrl string `protobuf:"bytes,1,opt,name=secret_url,json=secretUrl,proto3" json:"secret_url,omitempty"`
 	// The Key Vault holding the secret. Can be a literal ARM ID or a
-	// reference to an AzureKeyVault output.
+	// reference to an AzureKeyVault output. The snapshot reads its key out
+	// of the vault and lives in its own resource group, so the reference is
+	// access, not placement, on a diagram.
 	SourceVaultId *v1.StringValueOrRef `protobuf:"bytes,2,opt,name=source_vault_id,json=sourceVaultId,proto3" json:"source_vault_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -375,7 +379,8 @@ type AzureDiskSnapshotKeyEncryptionKey struct {
 	// The key's URL (the Key Vault key identifier).
 	KeyUrl string `protobuf:"bytes,1,opt,name=key_url,json=keyUrl,proto3" json:"key_url,omitempty"`
 	// The Key Vault holding the key. Can be a literal ARM ID or a
-	// reference to an AzureKeyVault output.
+	// reference to an AzureKeyVault output. Access, not placement, on a
+	// diagram, for the same reason as the disk encryption key's vault.
 	SourceVaultId *v1.StringValueOrRef `protobuf:"bytes,2,opt,name=source_vault_id,json=sourceVaultId,proto3" json:"source_vault_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -429,7 +434,7 @@ var File_catalog_azure_azuredisksnapshot_v1alpha1_spec_proto protoreflect.FileDe
 
 const file_catalog_azure_azuredisksnapshot_v1alpha1_spec_proto_rawDesc = "" +
 	"\n" +
-	"3catalog/azure/azuredisksnapshot/v1alpha1/spec.proto\x12,dev.planton.azure.azuredisksnapshot.v1alpha1\x1a\x1bbuf/validate/validate.proto\x1a&shared/foreignkey/v1/foreign_key.proto\"\x9c\v\n" +
+	"3catalog/azure/azuredisksnapshot/v1alpha1/spec.proto\x12,dev.planton.azure.azuredisksnapshot.v1alpha1\x1a\x1bbuf/validate/validate.proto\x1a&shared/foreignkey/v1/foreign_key.proto\"\xa0\v\n" +
 	"\x15AzureDiskSnapshotSpec\x12\x8c\x01\n" +
 	"\x0eresource_group\x18\x01 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB1\xbaH\x03\xc8\x01\x01\x88\xd4a\xd0\x0f\x92\xd4a\"status.outputs.resource_group_nameR\rresourceGroup\x12\xab\x01\n" +
 	"\x04name\x18\x02 \x01(\tB\x96\x01\xbaH\x92\x01\xba\x01\x8b\x01\n" +
@@ -439,8 +444,8 @@ const file_catalog_azure_azuredisksnapshot_v1alpha1_spec_proto_rawDesc = "" +
 	"\rcreate_option\x18\x04 \x01(\tB\x16\xbaH\x13\xc8\x01\x01r\x0eR\x04CopyR\x06ImportR\fcreateOption\x12\x81\x01\n" +
 	"\x12source_resource_id\x18\x05 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB\x1f\x88\xd4a\xe7\x0f\x92\xd4a\x16status.outputs.disk_idR\x10sourceResourceId\x12\x1d\n" +
 	"\n" +
-	"source_uri\x18\x06 \x01(\tR\tsourceUri\x12\x8c\x01\n" +
-	"\x12storage_account_id\x18\a \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB*\x88\xd4a\xd9\x0f\x92\xd4a!status.outputs.storage_account_idR\x10storageAccountId\x12/\n" +
+	"source_uri\x18\x06 \x01(\tR\tsourceUri\x12\x90\x01\n" +
+	"\x12storage_account_id\x18\a \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB.\x88\xd4a\xd9\x0f\x92\xd4a!status.outputs.storage_account_id\x98\xd4a\x01R\x10storageAccountId\x12/\n" +
 	"\x13incremental_enabled\x18\b \x01(\bR\x12incrementalEnabled\x12.\n" +
 	"\fdisk_size_gb\x18\t \x01(\x05B\a\xbaH\x04\x1a\x02(\x01H\x00R\n" +
 	"diskSizeGb\x88\x01\x01\x12\\\n" +
@@ -457,16 +462,16 @@ const file_catalog_azure_azuredisksnapshot_v1alpha1_spec_proto_rawDesc = "" +
 	"\x1e_public_network_access_enabled\"\xaf\x02\n" +
 	"#AzureDiskSnapshotEncryptionSettings\x12\x88\x01\n" +
 	"\x13disk_encryption_key\x18\x01 \x01(\v2P.dev.planton.azure.azuredisksnapshot.v1alpha1.AzureDiskSnapshotDiskEncryptionKeyB\x06\xbaH\x03\xc8\x01\x01R\x11diskEncryptionKey\x12}\n" +
-	"\x12key_encryption_key\x18\x02 \x01(\v2O.dev.planton.azure.azuredisksnapshot.v1alpha1.AzureDiskSnapshotKeyEncryptionKeyR\x10keyEncryptionKey\"\xd8\x01\n" +
+	"\x12key_encryption_key\x18\x02 \x01(\v2O.dev.planton.azure.azuredisksnapshot.v1alpha1.AzureDiskSnapshotKeyEncryptionKeyR\x10keyEncryptionKey\"\xdc\x01\n" +
 	"\"AzureDiskSnapshotDiskEncryptionKey\x12)\n" +
 	"\n" +
 	"secret_url\x18\x01 \x01(\tB\n" +
-	"\xbaH\a\xc8\x01\x01r\x02\x10\x01R\tsecretUrl\x12\x86\x01\n" +
-	"\x0fsource_vault_id\x18\x02 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB*\xbaH\x03\xc8\x01\x01\x88\xd4a\xd5\x0f\x92\xd4a\x1bstatus.outputs.key_vault_idR\rsourceVaultId\"\xd1\x01\n" +
+	"\xbaH\a\xc8\x01\x01r\x02\x10\x01R\tsecretUrl\x12\x8a\x01\n" +
+	"\x0fsource_vault_id\x18\x02 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB.\xbaH\x03\xc8\x01\x01\x88\xd4a\xd5\x0f\x92\xd4a\x1bstatus.outputs.key_vault_id\x98\xd4a\x01R\rsourceVaultId\"\xd5\x01\n" +
 	"!AzureDiskSnapshotKeyEncryptionKey\x12#\n" +
 	"\akey_url\x18\x01 \x01(\tB\n" +
-	"\xbaH\a\xc8\x01\x01r\x02\x10\x01R\x06keyUrl\x12\x86\x01\n" +
-	"\x0fsource_vault_id\x18\x02 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB*\xbaH\x03\xc8\x01\x01\x88\xd4a\xd5\x0f\x92\xd4a\x1bstatus.outputs.key_vault_idR\rsourceVaultIdB\xf3\x02\n" +
+	"\xbaH\a\xc8\x01\x01r\x02\x10\x01R\x06keyUrl\x12\x8a\x01\n" +
+	"\x0fsource_vault_id\x18\x02 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB.\xbaH\x03\xc8\x01\x01\x88\xd4a\xd5\x0f\x92\xd4a\x1bstatus.outputs.key_vault_id\x98\xd4a\x01R\rsourceVaultIdB\xf3\x02\n" +
 	"0com.dev.planton.azure.azuredisksnapshot.v1alpha1B\tSpecProtoP\x01Z_github.com/plantonhq/planton/catalog/azure/azuredisksnapshot/v1alpha1;azuredisksnapshotv1alpha1\xa2\x02\x04DPAA\xaa\x02,Dev.Planton.Azure.Azuredisksnapshot.V1alpha1\xca\x02,Dev\\Planton\\Azure\\Azuredisksnapshot\\V1alpha1\xe2\x028Dev\\Planton\\Azure\\Azuredisksnapshot\\V1alpha1\\GPBMetadata\xea\x020Dev::Planton::Azure::Azuredisksnapshot::V1alpha1b\x06proto3"
 
 var (

--- a/catalog/azure/azuredisksnapshot/v1alpha1/spec.proto
+++ b/catalog/azure/azuredisksnapshot/v1alpha1/spec.proto
@@ -94,11 +94,14 @@ message AzureDiskSnapshotSpec {
 
   // The storage account holding source_uri (the read grant for
   // "Import"). Can be a literal ARM ID or a reference to an
-  // AzureStorageAccount output.
+  // AzureStorageAccount output. The snapshot READS the VHD out of the
+  // account and lives in its own resource group, so the reference is
+  // access, not placement, on a diagram.
   //
   // **ForceNew**: changing this destroys and recreates the snapshot.
   dev.planton.shared.foreignkey.v1.StringValueOrRef storage_account_id = 7 [
     (dev.planton.shared.foreignkey.v1.default_kind) = AzureStorageAccount,
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true,
     (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.storage_account_id"
   ];
 
@@ -175,10 +178,13 @@ message AzureDiskSnapshotDiskEncryptionKey {
   ];
 
   // The Key Vault holding the secret. Can be a literal ARM ID or a
-  // reference to an AzureKeyVault output.
+  // reference to an AzureKeyVault output. The snapshot reads its key out
+  // of the vault and lives in its own resource group, so the reference is
+  // access, not placement, on a diagram.
   dev.planton.shared.foreignkey.v1.StringValueOrRef source_vault_id = 2 [
     (buf.validate.field).required = true,
     (dev.planton.shared.foreignkey.v1.default_kind) = AzureKeyVault,
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true,
     (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.key_vault_id"
   ];
 }
@@ -192,10 +198,12 @@ message AzureDiskSnapshotKeyEncryptionKey {
   ];
 
   // The Key Vault holding the key. Can be a literal ARM ID or a
-  // reference to an AzureKeyVault output.
+  // reference to an AzureKeyVault output. Access, not placement, on a
+  // diagram, for the same reason as the disk encryption key's vault.
   dev.planton.shared.foreignkey.v1.StringValueOrRef source_vault_id = 2 [
     (buf.validate.field).required = true,
     (dev.planton.shared.foreignkey.v1.default_kind) = AzureKeyVault,
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true,
     (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.key_vault_id"
   ];
 }

--- a/shared/cloudresourcekind/cloud_resource_kind.pb.go
+++ b/shared/cloudresourcekind/cloud_resource_kind.pb.go
@@ -1569,7 +1569,12 @@ const (
 	// The Azure Compute Gallery -- the shared library an organization
 	// keeps its approved VM images in. Image definitions
 	// (AzureComputeGalleryImage) live inside it; VMs and scale sets
-	// deploy from their published, region-replicated versions.
+	// deploy from their published, region-replicated versions. A container
+	// kind: every image definition is an ARM child of its gallery
+	// ({gallery_id}/images/{name}), so on a diagram the definitions stand
+	// inside the library that publishes them. The image ids a VM, a scale
+	// set, or a disk boots from are plain strings and never place anything
+	// inside the gallery.
 	CloudResourceKind_AzureComputeGallery CloudResourceKind = 2205
 	// A gallery image ({gallery_id}/images/{name}) -- one image
 	// definition inside a Compute Gallery (marketplace-style identity,
@@ -4196,7 +4201,7 @@ const file_shared_cloudresourcekind_cloud_resource_kind_proto_rawDesc = "" +
 	"\x1cKubernetesManifestProjection\x12\x1f\n" +
 	"\vapi_version\x18\x01 \x01(\tR\n" +
 	"apiVersion\x12\x12\n" +
-	"\x04kind\x18\x02 \x01(\tR\x04kind*\x96\xdb\x02\n" +
+	"\x04kind\x18\x02 \x01(\tR\x04kind*\x98\xdb\x02\n" +
 	"\x11CloudResourceKind\x12\x0f\n" +
 	"\vunspecified\x10\x00\x12b\n" +
 	"\x18TestCloudResourceGeneric\x10\x01\x1aD\xa2\xf7\x04@\b\x01\x12\bv1alpha2\"\x04tcrgJ,\n" +
@@ -4622,8 +4627,8 @@ const file_shared_cloudresourcekind_cloud_resource_kind_proto_rawDesc = "" +
 	"\x1dAzureDataFactoryLinkedService\x10\x99\x11\x1a\x1f\xa2\xf7\x04\x1b\b\r\x12\bv1alpha1\"\x06azdfls:\x02\x96\x11P\xd1\x01\x12=\n" +
 	"\x17AzureDataFactoryDataset\x10\x9a\x11\x1a\x1f\xa2\xf7\x04\x1b\b\r\x12\bv1alpha1\"\x06azdfds:\x02\x99\x11P\xd1\x01\x12A\n" +
 	"\x17AzureDataFactoryTrigger\x10\x9b\x11\x1a#\xa2\xf7\x04\x1f\b\r\x12\bv1alpha1\"\bazdftrig:\x04\x96\x11\x97\x11P\xd1\x01\x12H\n" +
-	"\"AzureDataFactoryIntegrationRuntime\x10\x9c\x11\x1a\x1f\xa2\xf7\x04\x1b\b\r\x12\bv1alpha1\"\x06azdfir:\x02\x96\x11P\xd1\x01\x129\n" +
-	"\x13AzureComputeGallery\x10\x9d\x11\x1a\x1f\xa2\xf7\x04\x1b\b\r\x12\bv1alpha1\"\x06azcgal:\x02\xd0\x0fP\xc8\x01\x12?\n" +
+	"\"AzureDataFactoryIntegrationRuntime\x10\x9c\x11\x1a\x1f\xa2\xf7\x04\x1b\b\r\x12\bv1alpha1\"\x06azdfir:\x02\x96\x11P\xd1\x01\x12;\n" +
+	"\x13AzureComputeGallery\x10\x9d\x11\x1a!\xa2\xf7\x04\x1d\b\r\x12\bv1alpha1\"\x06azcgal0\x01:\x02\xd0\x0fP\xc8\x01\x12?\n" +
 	"\x18AzureComputeGalleryImage\x10\x9e\x11\x1a \xa2\xf7\x04\x1c\b\r\x12\bv1alpha1\"\aazcgimg:\x02\x9d\x11P\xc8\x01\x12;\n" +
 	"\x14AzureAvailabilitySet\x10\x9f\x11\x1a \xa2\xf7\x04\x1c\b\r\x12\bv1alpha1\"\aazavset:\x02\xd0\x0fP\xc8\x01\x128\n" +
 	"\x11AzureDiskSnapshot\x10\xa0\x11\x1a \xa2\xf7\x04\x1c\b\r\x12\bv1alpha1\"\aazdsnap:\x02\xe7\x0fP\xc8\x01\x12;\n" +

--- a/shared/cloudresourcekind/cloud_resource_kind.proto
+++ b/shared/cloudresourcekind/cloud_resource_kind.proto
@@ -4226,12 +4226,18 @@ enum CloudResourceKind {
   // The Azure Compute Gallery -- the shared library an organization
   // keeps its approved VM images in. Image definitions
   // (AzureComputeGalleryImage) live inside it; VMs and scale sets
-  // deploy from their published, region-replicated versions.
+  // deploy from their published, region-replicated versions. A container
+  // kind: every image definition is an ARM child of its gallery
+  // ({gallery_id}/images/{name}), so on a diagram the definitions stand
+  // inside the library that publishes them. The image ids a VM, a scale
+  // set, or a disk boots from are plain strings and never place anything
+  // inside the gallery.
   AzureComputeGallery = 2205 [(kind_meta) = {
     provider: azure
     version: "v1alpha1"
     id_prefix: "azcgal"
     prerequisites: [AzureResourceGroup]
+    container_kind: true
     service_group: azure_compute
   }];
   // A gallery image ({gallery_id}/images/{name}) -- one image

--- a/shared/cloudresourcekind/testdata/containment_decisions.txt
+++ b/shared/cloudresourcekind/testdata/containment_decisions.txt
@@ -144,8 +144,8 @@ contained dev.planton.azure.azurecognitiveaccount.v1alpha1.AzureCognitiveAccount
 contained dev.planton.azure.azurecognitiveaccount.v1alpha1.AzureCognitiveAccountStorage.storage_account_id -> AzureStorageAccount
 contained dev.planton.azure.azurecognitiveaccount.v1alpha1.AzureCognitiveAccountVirtualNetworkRule.subnet_id -> AzureSubnet
 contained dev.planton.azure.azurecomputegallery.v1alpha1.AzureComputeGallerySpec.resource_group -> AzureResourceGroup
+contained dev.planton.azure.azurecomputegalleryimage.v1alpha1.AzureComputeGalleryImageSpec.gallery_name -> AzureComputeGallery
 contained dev.planton.azure.azurecomputegalleryimage.v1alpha1.AzureComputeGalleryImageSpec.resource_group -> AzureResourceGroup
-contained dev.planton.azure.azurecomputegalleryimage.v1alpha1.AzureComputeGalleryImageVersion.storage_account_id -> AzureStorageAccount
 contained dev.planton.azure.azurecontainerapp.v1alpha1.AzureContainerAppSpec.container_app_environment_id -> AzureContainerAppEnvironment
 contained dev.planton.azure.azurecontainerapp.v1alpha1.AzureContainerAppSpec.resource_group -> AzureResourceGroup
 contained dev.planton.azure.azurecontainerappenvironment.v1alpha1.AzureContainerAppEnvironmentSpec.infrastructure_subnet_id -> AzureSubnet
@@ -186,10 +186,7 @@ contained dev.planton.azure.azuredataprotectionbackupinstance.v1alpha1.AzureData
 contained dev.planton.azure.azuredataprotectionbackupvault.v1alpha1.AzureDataProtectionBackupVaultSpec.resource_group -> AzureResourceGroup
 contained dev.planton.azure.azuredataprotectionresourceguard.v1alpha1.AzureDataProtectionResourceGuardSpec.resource_group -> AzureResourceGroup
 contained dev.planton.azure.azurediskencryptionset.v1alpha1.AzureDiskEncryptionSetSpec.resource_group -> AzureResourceGroup
-contained dev.planton.azure.azuredisksnapshot.v1alpha1.AzureDiskSnapshotDiskEncryptionKey.source_vault_id -> AzureKeyVault
-contained dev.planton.azure.azuredisksnapshot.v1alpha1.AzureDiskSnapshotKeyEncryptionKey.source_vault_id -> AzureKeyVault
 contained dev.planton.azure.azuredisksnapshot.v1alpha1.AzureDiskSnapshotSpec.resource_group -> AzureResourceGroup
-contained dev.planton.azure.azuredisksnapshot.v1alpha1.AzureDiskSnapshotSpec.storage_account_id -> AzureStorageAccount
 contained dev.planton.azure.azurednsrecord.v1alpha1.AzureDnsRecordSpec.resource_group -> AzureResourceGroup
 contained dev.planton.azure.azurednsrecord.v1alpha1.AzureDnsRecordSpec.zone_name -> AzureDnsZone
 contained dev.planton.azure.azurednszone.v1alpha1.AzureDnsZoneSpec.resource_group -> AzureResourceGroup
@@ -685,9 +682,13 @@ exempt    dev.planton.aws.awsvpcendpoint.v1alpha1.AwsVpcEndpointSpec.route_table
 exempt    dev.planton.azure.azureakscluster.v1alpha1.AzureAksClusterServiceMeshCertificateAuthority.key_vault_id -> AzureKeyVault
 exempt    dev.planton.azure.azureakscluster.v1alpha1.AzureAksClusterSpec.private_dns_zone_id -> AzurePrivateDnsZone
 exempt    dev.planton.azure.azureakscluster.v1alpha1.AzureAksClusterWebAppRouting.dns_zone_ids -> AzureDnsZone
+exempt    dev.planton.azure.azurecomputegalleryimage.v1alpha1.AzureComputeGalleryImageVersion.storage_account_id -> AzureStorageAccount
 exempt    dev.planton.azure.azurecontainerappenvironmentstorage.v1alpha1.AzureContainerAppEnvironmentStorageSpec.access_key -> AzureStorageAccount
 exempt    dev.planton.azure.azurecontainerappenvironmentstorage.v1alpha1.AzureContainerAppEnvironmentStorageSpec.account_name -> AzureStorageAccount
 exempt    dev.planton.azure.azurecosmosdbaccount.v1alpha1.AzureCosmosdbAccountVirtualNetworkRule.subnet_id -> AzureSubnet
+exempt    dev.planton.azure.azuredisksnapshot.v1alpha1.AzureDiskSnapshotDiskEncryptionKey.source_vault_id -> AzureKeyVault
+exempt    dev.planton.azure.azuredisksnapshot.v1alpha1.AzureDiskSnapshotKeyEncryptionKey.source_vault_id -> AzureKeyVault
+exempt    dev.planton.azure.azuredisksnapshot.v1alpha1.AzureDiskSnapshotSpec.storage_account_id -> AzureStorageAccount
 exempt    dev.planton.azure.azureeventhub.v1alpha1.AzureEventHubCaptureDestination.storage_account_id -> AzureStorageAccount
 exempt    dev.planton.azure.azureeventhubdisasterrecoveryconfig.v1alpha1.AzureEventHubDisasterRecoveryConfigSpec.partner_namespace_id -> AzureEventHubNamespace
 exempt    dev.planton.azure.azureeventhubnamespace.v1alpha1.AzureEventHubNamespaceVirtualNetworkRule.subnet_id -> AzureSubnet


### PR DESCRIPTION
## What changed

- **Four references in the compute family are containment-exempt**, because each names a container the resource merely reads from: a disk snapshot's `storage_account_id` (the VHD it is imported from) and the two `source_vault_id` fields of its legacy Azure Disk Encryption settings (the vault holding its disk-encryption secret and its key-encryption key), and a gallery image version's `storage_account_id` (the page blob it is built from). A snapshot lives in its own resource group and a version lives in its gallery; without the exemptions a backup artifact would be drawn inside the account or vault it consulted -- the Network Watcher flow log's and the virtual machine's Key Vault secrets' reasoning, applied to their siblings.
- **`AzureComputeGallery` is a container kind.** The kind metadata already said it in words -- "image definitions live inside it" -- and ARM nests them (`{gallery_id}/images/{name}`); it now says it with `container_kind: true`, so the containment resolvers nest every image definition inside the library that publishes it. The image ids a VM, a scale set, or a disk boots from are plain strings and never place anything inside the gallery, so no exemption needs to travel with the mark.
- The containment-decision registry moves exactly four lines from `contained` to `exempt` and gains exactly one `contained` line (`AzureComputeGalleryImageSpec.gallery_name`, the only typed reference into a gallery across the catalog). Nothing else moved.
- Go stubs regenerated with the pinned `protoc-gen-go v1.36.6` (comments and option bytes only); `buf lint` and `buf format -d` clean on the touched paths.

## Why

`containment_exempt` says a reference into a container is access, not placement; `container_kind` says a kind is a box other resources nest inside. A snapshot restored from a customer's VHD is not a resident of the storage account it was read from, and a snapshot with disk-encryption settings is not a resident of the vault its key sits in; a gallery and its image definitions drawn as peer cards joined by lines hide the library shape Azure's own portal shows.

## How to check

```bash
go test ./shared/cloudresourcekind/...   # green; the golden carries the four exemptions and the gallery placement
grep -n -A8 'AzureComputeGallery = 2205' shared/cloudresourcekind/cloud_resource_kind.proto | grep container_kind
grep -n containment_exempt catalog/azure/azuredisksnapshot/v1alpha1/spec.proto catalog/azure/azurecomputegalleryimage/v1alpha1/spec.proto
```
