### PR TITLE
fix(catalog/azure): a container group, a backup instance, and a node pool reach what they name and never live in it

### DIFF
--- a/_changelog/2026-09/2026-09-10-133000-a-container-group-a-backup-and-a-node-pool-reach-what-they-name-and-never-live-in-it.md
+++ b/_changelog/2026-09/2026-09-10-133000-a-container-group-a-backup-and-a-node-pool-reach-what-they-name-and-never-live-in-it.md
@@ -1,0 +1,17 @@
+# A container group, a backup instance, and a node pool reach what they name and never live in it
+
+## What changed
+
+- **Six references in the Azure container family are containment-exempt.** A Container Instance that mounts an Azure Files share names the storage account holding it twice (`AzureContainerInstanceVolumeAzureFile.storage_account_name` and `.storage_account_key`); a Data Protection backup instance that protects an AKS cluster names it (`AzureDataProtectionBackupInstanceKubernetesCluster.kubernetes_cluster_id`); an AKS node pool names the subnet its nodes attach to and, on traditional Azure CNI, the subnet its pods draw addresses from (`AzureAksNodePoolSpec.vnet_subnet_id`, `.pod_subnet_id`); an AKS cluster whose ingress add-on deploys an Application Gateway names the subnet that gateway goes into (`AzureAksClusterIngressApplicationGateway.subnet_id`). Each of those resources READS, MOUNTS, PROTECTS, or ATTACHES TO what it names and lives somewhere else -- the container group in its own resource group or subnet, the backup in its vault, the node pool in its cluster (an ARM child: `managedClusters/{cluster}/agentPools/{pool}`), the cluster in its own node subnet -- so on a diagram every one of these references is access, not placement. The Container App environment's storage registration already carried the exemption on the identical pair of storage-account fields; the container group now agrees with it.
+- The containment-decision registry (`shared/cloudresourcekind/testdata/containment_decisions.txt`) moves exactly six lines from `contained` to `exempt`. Nothing else moved.
+
+## Why
+
+`containment_exempt` says a reference into a container is access, not placement. Without it, a container group mounting a share would be drawn inside the storage account it reads from; a backup would be drawn inside the cluster it protects; a node pool on its own subnet -- the shape Azure documents for segmenting an internet-exposed pool or for dynamic pod IP allocation -- would fall to a tie between its cluster and a subnet the cluster does not name, drawn by luck on a project diagram and left floating outside its cluster on the organization estate; and a cluster with an ingress add-on would be promoted out of its node subnet into the whole network. The pool's own subnet and the add-on's subnet stay on the picture as lines, which is what they are.
+
+## How to check
+
+```bash
+go test ./shared/cloudresourcekind/... -run TestContainmentDecisions   # green; the golden carries the six exemptions
+grep -n containment_exempt catalog/azure/azurecontainerinstance/v1alpha1/spec.proto catalog/azure/azuredataprotectionbackupinstance/v1alpha1/spec.proto catalog/azure/azureaksnodepool/v1alpha1/spec.proto catalog/azure/azureakscluster/v1alpha1/spec.proto
+```

--- a/catalog/azure/azureakscluster/v1alpha1/spec.pb.go
+++ b/catalog/azure/azureakscluster/v1alpha1/spec.pb.go
@@ -5449,7 +5449,9 @@ type AzureAksClusterIngressApplicationGateway struct {
 	// gateway, e.g. "10.225.0.0/24" (at least /27).
 	SubnetCidr string `protobuf:"bytes,3,opt,name=subnet_cidr,json=subnetCidr,proto3" json:"subnet_cidr,omitempty"`
 	// Existing subnet to host the new gateway -- must be dedicated to it
-	// and at least /27.
+	// and at least /27. The add-on's GATEWAY lives in this subnet; the
+	// cluster does not, so the reference is access, not placement, on a
+	// diagram -- the cluster's own node subnet places it.
 	SubnetId      *v1.StringValueOrRef `protobuf:"bytes,4,opt,name=subnet_id,json=subnetId,proto3" json:"subnet_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -6834,14 +6836,14 @@ const file_catalog_azure_azureakscluster_v1alpha1_spec_proto_rawDesc = "" +
 	"\x1alog_analytics_workspace_id\x18\x01 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB*\xbaH\x03\xc8\x01\x01\x88\xd4a\x82\x10\x92\xd4a\x1bstatus.outputs.workspace_idR\x17logAnalyticsWorkspaceId\"w\n" +
 	"\x1dAzureAksClusterMonitorMetrics\x12/\n" +
 	"\x13annotations_allowed\x18\x01 \x01(\tR\x12annotationsAllowed\x12%\n" +
-	"\x0elabels_allowed\x18\x02 \x01(\tR\rlabelsAllowed\"\xd1\x04\n" +
+	"\x0elabels_allowed\x18\x02 \x01(\tR\rlabelsAllowed\"\xd5\x04\n" +
 	"(AzureAksClusterIngressApplicationGateway\x12\x81\x01\n" +
 	"\n" +
 	"gateway_id\x18\x01 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB.\x88\xd4a\xe0\x0f\x92\xd4a%status.outputs.application_gateway_idR\tgatewayId\x12!\n" +
 	"\fgateway_name\x18\x02 \x01(\tR\vgatewayName\x12\x1f\n" +
 	"\vsubnet_cidr\x18\x03 \x01(\tR\n" +
-	"subnetCidr\x12r\n" +
-	"\tsubnet_id\x18\x04 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB!\x88\xd4a\xdb\x0f\x92\xd4a\x18status.outputs.subnet_idR\bsubnetId:\xe8\x01\xbaH\xe4\x01\x1a\xe1\x01\n" +
+	"subnetCidr\x12v\n" +
+	"\tsubnet_id\x18\x04 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB%\x88\xd4a\xdb\x0f\x92\xd4a\x18status.outputs.subnet_id\x98\xd4a\x01R\bsubnetId:\xe8\x01\xbaH\xe4\x01\x1a\xe1\x01\n" +
 	"\x1baks_agic_exactly_one_anchor\x12ZSet exactly one of gateway_id, subnet_cidr, or subnet_id to anchor the Application Gateway\x1af(has(this.gateway_id) ? 1 : 0) + (this.subnet_cidr != '' ? 1 : 0) + (has(this.subnet_id) ? 1 : 0) == 1\"K\n" +
 	" AzureAksClusterAciConnectorLinux\x12'\n" +
 	"\vsubnet_name\x18\x01 \x01(\tB\x06\xbaH\x03\xc8\x01\x01R\n" +

--- a/catalog/azure/azureakscluster/v1alpha1/spec.proto
+++ b/catalog/azure/azureakscluster/v1alpha1/spec.proto
@@ -2034,9 +2034,12 @@ message AzureAksClusterIngressApplicationGateway {
   string subnet_cidr = 3;
 
   // Existing subnet to host the new gateway -- must be dedicated to it
-  // and at least /27.
+  // and at least /27. The add-on's GATEWAY lives in this subnet; the
+  // cluster does not, so the reference is access, not placement, on a
+  // diagram -- the cluster's own node subnet places it.
   dev.planton.shared.foreignkey.v1.StringValueOrRef subnet_id = 4 [
     (dev.planton.shared.foreignkey.v1.default_kind) = AzureSubnet,
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true,
     (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.subnet_id"
   ];
 

--- a/catalog/azure/azureaksnodepool/v1alpha1/spec.pb.go
+++ b/catalog/azure/azureaksnodepool/v1alpha1/spec.pb.go
@@ -1099,11 +1099,16 @@ type AzureAksNodePoolSpec struct {
 	// cluster's node subnet -- correct for nearly every pool. Reference a
 	// different AzureSubnet to segment pools across subnets (e.g. a
 	// dedicated subnet for an internet-exposed pool). Changing it replaces
-	// the pool.
+	// the pool. A node pool is an ARM child of its cluster
+	// (managedClusters/{cluster}/agentPools/{pool}) and lives there on a
+	// diagram; the subnet is where its nodes attach, so the reference is
+	// access, not placement -- otherwise a pool on its own subnet would be
+	// drawn outside the cluster it belongs to.
 	VnetSubnetId *v1.StringValueOrRef `protobuf:"bytes,18,opt,name=vnet_subnet_id,json=vnetSubnetId,proto3" json:"vnet_subnet_id,omitempty"`
 	// A separate subnet for POD IPs (traditional Azure CNI with dynamic
 	// pod IP allocation). Only meaningful alongside vnet_subnet_id on
-	// clusters using non-overlay Azure CNI.
+	// clusters using non-overlay Azure CNI. Access, not placement, like
+	// vnet_subnet_id.
 	PodSubnetId *v1.StringValueOrRef `protobuf:"bytes,19,opt,name=pod_subnet_id,json=podSubnetId,proto3" json:"pod_subnet_id,omitempty"`
 	// Kubernetes version for this pool's nodes. Unset follows the control
 	// plane. Pools may lag the control plane by up to two minor versions
@@ -2340,7 +2345,7 @@ var File_catalog_azure_azureaksnodepool_v1alpha1_spec_proto protoreflect.FileDes
 
 const file_catalog_azure_azureaksnodepool_v1alpha1_spec_proto_rawDesc = "" +
 	"\n" +
-	"2catalog/azure/azureaksnodepool/v1alpha1/spec.proto\x12+dev.planton.azure.azureaksnodepool.v1alpha1\x1a\x1bbuf/validate/validate.proto\x1a&shared/foreignkey/v1/foreign_key.proto\x1a\x1cshared/options/options.proto\"\xae2\n" +
+	"2catalog/azure/azureaksnodepool/v1alpha1/spec.proto\x12+dev.planton.azure.azureaksnodepool.v1alpha1\x1a\x1bbuf/validate/validate.proto\x1a&shared/foreignkey/v1/foreign_key.proto\x1a\x1cshared/options/options.proto\"\xb62\n" +
 	"\x14AzureAksNodePoolSpec\x12\x90\x01\n" +
 	"\x15kubernetes_cluster_id\x18\x01 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB(\xbaH\x03\xc8\x01\x01\x88\xd4a\xd1\x0f\x92\xd4a\x19status.outputs.cluster_idR\x13kubernetesClusterId\x12\xc0\x01\n" +
 	"\x04name\x18\x02 \x01(\tB\xab\x01\xbaH\xa7\x01\xba\x01\xa0\x01\n" +
@@ -2366,9 +2371,9 @@ const file_catalog_azure_azureaksnodepool_v1alpha1_spec_proto_rawDesc = "" +
 	"nodeLabels\x12b\n" +
 	"\vnode_taints\x18\x10 \x03(\tBA\xbaH>\x92\x01;\"9r725^[^=]+=[^:]*:(NoSchedule|PreferNoSchedule|NoExecute)$R\n" +
 	"nodeTaints\x12)\n" +
-	"\x05zones\x18\x11 \x03(\tB\x13\xbaH\x10\x92\x01\r\"\vr\tR\x011R\x012R\x013R\x05zones\x12{\n" +
-	"\x0evnet_subnet_id\x18\x12 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB!\x88\xd4a\xdb\x0f\x92\xd4a\x18status.outputs.subnet_idR\fvnetSubnetId\x12y\n" +
-	"\rpod_subnet_id\x18\x13 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB!\x88\xd4a\xdb\x0f\x92\xd4a\x18status.outputs.subnet_idR\vpodSubnetId\x121\n" +
+	"\x05zones\x18\x11 \x03(\tB\x13\xbaH\x10\x92\x01\r\"\vr\tR\x011R\x012R\x013R\x05zones\x12\x7f\n" +
+	"\x0evnet_subnet_id\x18\x12 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB%\x88\xd4a\xdb\x0f\x92\xd4a\x18status.outputs.subnet_id\x98\xd4a\x01R\fvnetSubnetId\x12}\n" +
+	"\rpod_subnet_id\x18\x13 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB%\x88\xd4a\xdb\x0f\x92\xd4a\x18status.outputs.subnet_id\x98\xd4a\x01R\vpodSubnetId\x121\n" +
 	"\x14orchestrator_version\x18\x14 \x01(\tR\x13orchestratorVersion\x12%\n" +
 	"\x0fos_disk_size_gb\x18\x15 \x01(\x05R\fosDiskSizeGb\x12i\n" +
 	"\fos_disk_type\x18\x16 \x01(\x0e2G.dev.planton.azure.azureaksnodepool.v1alpha1.AzureAksNodePoolOsDiskTypeR\n" +

--- a/catalog/azure/azureaksnodepool/v1alpha1/spec.proto
+++ b/catalog/azure/azureaksnodepool/v1alpha1/spec.proto
@@ -155,17 +155,24 @@ message AzureAksNodePoolSpec {
   // cluster's node subnet -- correct for nearly every pool. Reference a
   // different AzureSubnet to segment pools across subnets (e.g. a
   // dedicated subnet for an internet-exposed pool). Changing it replaces
-  // the pool.
+  // the pool. A node pool is an ARM child of its cluster
+  // (managedClusters/{cluster}/agentPools/{pool}) and lives there on a
+  // diagram; the subnet is where its nodes attach, so the reference is
+  // access, not placement -- otherwise a pool on its own subnet would be
+  // drawn outside the cluster it belongs to.
   dev.planton.shared.foreignkey.v1.StringValueOrRef vnet_subnet_id = 18 [
     (dev.planton.shared.foreignkey.v1.default_kind) = AzureSubnet,
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true,
     (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.subnet_id"
   ];
 
   // A separate subnet for POD IPs (traditional Azure CNI with dynamic
   // pod IP allocation). Only meaningful alongside vnet_subnet_id on
-  // clusters using non-overlay Azure CNI.
+  // clusters using non-overlay Azure CNI. Access, not placement, like
+  // vnet_subnet_id.
   dev.planton.shared.foreignkey.v1.StringValueOrRef pod_subnet_id = 19 [
     (dev.planton.shared.foreignkey.v1.default_kind) = AzureSubnet,
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true,
     (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.subnet_id"
   ];
 

--- a/catalog/azure/azurecontainerinstance/v1alpha1/spec.pb.go
+++ b/catalog/azure/azurecontainerinstance/v1alpha1/spec.pb.go
@@ -932,12 +932,16 @@ type AzureContainerInstanceVolumeAzureFile struct {
 	// AzureStorageShare output.
 	ShareName *v1.StringValueOrRef `protobuf:"bytes,1,opt,name=share_name,json=shareName,proto3" json:"share_name,omitempty"`
 	// The storage account holding the share. Can be a literal or a
-	// reference to an AzureStorageAccount output.
+	// reference to an AzureStorageAccount output. The container group
+	// MOUNTS the share and lives in its own resource group (or its subnet),
+	// so the reference is access, not placement, on a diagram -- the same
+	// reasoning the Container App environment's storage registration
+	// carries for the identical pair of fields.
 	StorageAccountName *v1.StringValueOrRef `protobuf:"bytes,2,opt,name=storage_account_name,json=storageAccountName,proto3" json:"storage_account_name,omitempty"`
 	// The storage account's access key. SECRET -- Azure never returns it
 	// on reads; both engines re-send it from configuration on updates.
 	// Reference an AzureStorageAccount's primary_access_key output or
-	// pass a literal.
+	// pass a literal. Access, not placement, like storage_account_name.
 	StorageAccountKey *v1.StringValueOrRef `protobuf:"bytes,3,opt,name=storage_account_key,json=storageAccountKey,proto3" json:"storage_account_key,omitempty"`
 	unknownFields     protoimpl.UnknownFields
 	sizeCache         protoimpl.SizeCache
@@ -1731,12 +1735,12 @@ const file_catalog_azure_azurecontainerinstance_v1alpha1_spec_proto_rawDesc = ""
 	"\vSecretEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01:\xff\x01\xbaH\xfb\x01\x1a\xf8\x01\n" +
-	"*container_instance_volume_exactly_one_form\x12Gset exactly one volume form: azure_file, empty_dir, git_repo, or secret\x1a\x80\x01(has(this.azure_file) ? 1 : 0) + (this.empty_dir ? 1 : 0) + (has(this.git_repo) ? 1 : 0) + (this.secret.size() > 0 ? 1 : 0) == 1\"\xda\x03\n" +
+	"*container_instance_volume_exactly_one_form\x12Gset exactly one volume form: azure_file, empty_dir, git_repo, or secret\x1a\x80\x01(has(this.azure_file) ? 1 : 0) + (this.empty_dir ? 1 : 0) + (has(this.git_repo) ? 1 : 0) + (this.secret.size() > 0 ? 1 : 0) == 1\"\xe2\x03\n" +
 	"%AzureContainerInstanceVolumeAzureFile\x12{\n" +
 	"\n" +
-	"share_name\x18\x01 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB(\xbaH\x03\xc8\x01\x01\x88\xd4a\xab\x10\x92\xd4a\x19status.outputs.share_nameR\tshareName\x12\x98\x01\n" +
-	"\x14storage_account_name\x18\x02 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB2\xbaH\x03\xc8\x01\x01\x88\xd4a\xd9\x0f\x92\xd4a#status.outputs.storage_account_nameR\x12storageAccountName\x12\x98\x01\n" +
-	"\x13storage_account_key\x18\x03 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB4\xbaH\x03\xc8\x01\x01\xa0\xa6\x1d\x01\x88\xd4a\xd9\x0f\x92\xd4a!status.outputs.primary_access_keyR\x11storageAccountKey\"}\n" +
+	"share_name\x18\x01 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB(\xbaH\x03\xc8\x01\x01\x88\xd4a\xab\x10\x92\xd4a\x19status.outputs.share_nameR\tshareName\x12\x9c\x01\n" +
+	"\x14storage_account_name\x18\x02 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB6\xbaH\x03\xc8\x01\x01\x88\xd4a\xd9\x0f\x92\xd4a#status.outputs.storage_account_name\x98\xd4a\x01R\x12storageAccountName\x12\x9c\x01\n" +
+	"\x13storage_account_key\x18\x03 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB8\xbaH\x03\xc8\x01\x01\xa0\xa6\x1d\x01\x88\xd4a\xd9\x0f\x92\xd4a!status.outputs.primary_access_key\x98\xd4a\x01R\x11storageAccountKey\"}\n" +
 	"#AzureContainerInstanceVolumeGitRepo\x12\x1c\n" +
 	"\x03url\x18\x01 \x01(\tB\n" +
 	"\xbaH\a\xc8\x01\x01r\x02\x10\x01R\x03url\x12\x1c\n" +

--- a/catalog/azure/azurecontainerinstance/v1alpha1/spec.proto
+++ b/catalog/azure/azurecontainerinstance/v1alpha1/spec.proto
@@ -499,21 +499,27 @@ message AzureContainerInstanceVolumeAzureFile {
   ];
 
   // The storage account holding the share. Can be a literal or a
-  // reference to an AzureStorageAccount output.
+  // reference to an AzureStorageAccount output. The container group
+  // MOUNTS the share and lives in its own resource group (or its subnet),
+  // so the reference is access, not placement, on a diagram -- the same
+  // reasoning the Container App environment's storage registration
+  // carries for the identical pair of fields.
   dev.planton.shared.foreignkey.v1.StringValueOrRef storage_account_name = 2 [
     (buf.validate.field).required = true,
     (dev.planton.shared.foreignkey.v1.default_kind) = AzureStorageAccount,
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true,
     (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.storage_account_name"
   ];
 
   // The storage account's access key. SECRET -- Azure never returns it
   // on reads; both engines re-send it from configuration on updates.
   // Reference an AzureStorageAccount's primary_access_key output or
-  // pass a literal.
+  // pass a literal. Access, not placement, like storage_account_name.
   dev.planton.shared.foreignkey.v1.StringValueOrRef storage_account_key = 3 [
     (buf.validate.field).required = true,
     (dev.planton.shared.options.sensitive) = true,
     (dev.planton.shared.foreignkey.v1.default_kind) = AzureStorageAccount,
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true,
     (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.primary_access_key"
   ];
 }

--- a/catalog/azure/azuredataprotectionbackupinstance/v1alpha1/spec.pb.go
+++ b/catalog/azure/azuredataprotectionbackupinstance/v1alpha1/spec.pb.go
@@ -350,7 +350,8 @@ type AzureDataProtectionBackupInstanceKubernetesCluster struct {
 	// cluster must carry the AKS Backup extension and its
 	// trusted-access role binding to the vault before create -- an
 	// apply-time contract Azure enforces, not something this spec can
-	// check.
+	// check. The backup instance PROTECTS the cluster and lives in its
+	// vault, so the reference is access, not placement, on a diagram.
 	KubernetesClusterId *v1.StringValueOrRef `protobuf:"bytes,1,opt,name=kubernetes_cluster_id,json=kubernetesClusterId,proto3" json:"kubernetes_cluster_id,omitempty"`
 	// The resource group (by name) where Azure Backup stores the
 	// cluster's snapshots. Fixed at creation.
@@ -705,9 +706,9 @@ const file_catalog_azure_azuredataprotectionbackupinstance_v1alpha1_spec_proto_r
 	"\adisk_id\x18\x01 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB%\xbaH\x03\xc8\x01\x01\x88\xd4a\xe7\x0f\x92\xd4a\x16status.outputs.disk_idR\x06diskId\x12\xa6\x01\n" +
 	"\x1csnapshot_resource_group_name\x18\x02 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB1\xbaH\x03\xc8\x01\x01\x88\xd4a\xd0\x0f\x92\xd4a\"status.outputs.resource_group_nameR\x19snapshotResourceGroupName\x12G\n" +
 	"\x18snapshot_subscription_id\x18\x03 \x01(\tB\b\xbaH\x05r\x03\xb0\x01\x01H\x00R\x16snapshotSubscriptionId\x88\x01\x01B\x1b\n" +
-	"\x19_snapshot_subscription_id\"\xba\x04\n" +
-	"2AzureDataProtectionBackupInstanceKubernetesCluster\x12\x90\x01\n" +
-	"\x15kubernetes_cluster_id\x18\x01 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB(\xbaH\x03\xc8\x01\x01\x88\xd4a\xd1\x0f\x92\xd4a\x19status.outputs.cluster_idR\x13kubernetesClusterId\x12\xa6\x01\n" +
+	"\x19_snapshot_subscription_id\"\xbe\x04\n" +
+	"2AzureDataProtectionBackupInstanceKubernetesCluster\x12\x94\x01\n" +
+	"\x15kubernetes_cluster_id\x18\x01 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB,\xbaH\x03\xc8\x01\x01\x88\xd4a\xd1\x0f\x92\xd4a\x19status.outputs.cluster_id\x98\xd4a\x01R\x13kubernetesClusterId\x12\xa6\x01\n" +
 	"\x1csnapshot_resource_group_name\x18\x02 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB1\xbaH\x03\xc8\x01\x01\x88\xd4a\xd0\x0f\x92\xd4a\"status.outputs.resource_group_nameR\x19snapshotResourceGroupName\x12\xc7\x01\n" +
 	"\x1cbackup_datasource_parameters\x18\x03 \x01(\v2\x84\x01.dev.planton.azure.azuredataprotectionbackupinstance.v1alpha1.AzureDataProtectionBackupInstanceKubernetesClusterDatasourceParametersR\x1abackupDatasourceParameters\"\xc4\x03\n" +
 	"FAzureDataProtectionBackupInstanceKubernetesClusterDatasourceParameters\x12/\n" +

--- a/catalog/azure/azuredataprotectionbackupinstance/v1alpha1/spec.proto
+++ b/catalog/azure/azuredataprotectionbackupinstance/v1alpha1/spec.proto
@@ -165,10 +165,12 @@ message AzureDataProtectionBackupInstanceKubernetesCluster {
   // cluster must carry the AKS Backup extension and its
   // trusted-access role binding to the vault before create -- an
   // apply-time contract Azure enforces, not something this spec can
-  // check.
+  // check. The backup instance PROTECTS the cluster and lives in its
+  // vault, so the reference is access, not placement, on a diagram.
   dev.planton.shared.foreignkey.v1.StringValueOrRef kubernetes_cluster_id = 1 [
     (buf.validate.field).required = true,
     (dev.planton.shared.foreignkey.v1.default_kind) = AzureAksCluster,
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true,
     (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.cluster_id"
   ];
 

--- a/shared/cloudresourcekind/testdata/containment_decisions.txt
+++ b/shared/cloudresourcekind/testdata/containment_decisions.txt
@@ -117,11 +117,8 @@ contained dev.planton.azure.azureaifoundry.v1alpha1.AzureAiFoundrySpec.storage_a
 contained dev.planton.azure.azureakscluster.v1alpha1.AzureAksClusterApiServerAccessProfile.subnet_id -> AzureSubnet
 contained dev.planton.azure.azureakscluster.v1alpha1.AzureAksClusterDefaultNodePool.pod_subnet_id -> AzureSubnet
 contained dev.planton.azure.azureakscluster.v1alpha1.AzureAksClusterDefaultNodePool.vnet_subnet_id -> AzureSubnet
-contained dev.planton.azure.azureakscluster.v1alpha1.AzureAksClusterIngressApplicationGateway.subnet_id -> AzureSubnet
 contained dev.planton.azure.azureakscluster.v1alpha1.AzureAksClusterSpec.resource_group -> AzureResourceGroup
 contained dev.planton.azure.azureaksnodepool.v1alpha1.AzureAksNodePoolSpec.kubernetes_cluster_id -> AzureAksCluster
-contained dev.planton.azure.azureaksnodepool.v1alpha1.AzureAksNodePoolSpec.pod_subnet_id -> AzureSubnet
-contained dev.planton.azure.azureaksnodepool.v1alpha1.AzureAksNodePoolSpec.vnet_subnet_id -> AzureSubnet
 contained dev.planton.azure.azureapplicationgateway.v1alpha1.AzureApplicationGatewayFrontendIpConfiguration.subnet_id -> AzureSubnet
 contained dev.planton.azure.azureapplicationgateway.v1alpha1.AzureApplicationGatewayPrivateLinkIpConfiguration.subnet_id -> AzureSubnet
 contained dev.planton.azure.azureapplicationgateway.v1alpha1.AzureApplicationGatewaySpec.resource_group -> AzureResourceGroup
@@ -158,8 +155,6 @@ contained dev.planton.azure.azurecontainerappjob.v1alpha1.AzureContainerAppJobSp
 contained dev.planton.azure.azurecontainerappjob.v1alpha1.AzureContainerAppJobSpec.resource_group -> AzureResourceGroup
 contained dev.planton.azure.azurecontainerinstance.v1alpha1.AzureContainerInstanceSpec.resource_group -> AzureResourceGroup
 contained dev.planton.azure.azurecontainerinstance.v1alpha1.AzureContainerInstanceSpec.subnet_id -> AzureSubnet
-contained dev.planton.azure.azurecontainerinstance.v1alpha1.AzureContainerInstanceVolumeAzureFile.storage_account_key -> AzureStorageAccount
-contained dev.planton.azure.azurecontainerinstance.v1alpha1.AzureContainerInstanceVolumeAzureFile.storage_account_name -> AzureStorageAccount
 contained dev.planton.azure.azurecontainerregistry.v1alpha1.AzureContainerRegistrySpec.resource_group -> AzureResourceGroup
 contained dev.planton.azure.azurecosmosdbaccount.v1alpha1.AzureCosmosdbAccountSpec.resource_group -> AzureResourceGroup
 contained dev.planton.azure.azurecosmosdbmongocollection.v1alpha1.AzureCosmosdbMongoCollectionSpec.mongo_database_id -> AzureCosmosdbMongoDatabase
@@ -181,7 +176,6 @@ contained dev.planton.azure.azuredatafactorytrigger.v1alpha1.AzureDataFactoryTri
 contained dev.planton.azure.azuredataprotectionbackupinstance.v1alpha1.AzureDataProtectionBackupInstanceBlobStorage.storage_account_id -> AzureStorageAccount
 contained dev.planton.azure.azuredataprotectionbackupinstance.v1alpha1.AzureDataProtectionBackupInstanceDataLakeStorage.storage_account_id -> AzureStorageAccount
 contained dev.planton.azure.azuredataprotectionbackupinstance.v1alpha1.AzureDataProtectionBackupInstanceDisk.snapshot_resource_group_name -> AzureResourceGroup
-contained dev.planton.azure.azuredataprotectionbackupinstance.v1alpha1.AzureDataProtectionBackupInstanceKubernetesCluster.kubernetes_cluster_id -> AzureAksCluster
 contained dev.planton.azure.azuredataprotectionbackupinstance.v1alpha1.AzureDataProtectionBackupInstanceKubernetesCluster.snapshot_resource_group_name -> AzureResourceGroup
 contained dev.planton.azure.azuredataprotectionbackupvault.v1alpha1.AzureDataProtectionBackupVaultSpec.resource_group -> AzureResourceGroup
 contained dev.planton.azure.azuredataprotectionresourceguard.v1alpha1.AzureDataProtectionResourceGuardSpec.resource_group -> AzureResourceGroup
@@ -682,12 +676,18 @@ exempt    dev.planton.aws.awsroute53zone.v1alpha1.AwsRoute53ZoneVpcAssociation.v
 exempt    dev.planton.aws.awssagemakerdomain.v1alpha1.AwsSagemakerDomainEfsFileSystemConfig.file_system_id -> AwsElasticFileSystem
 exempt    dev.planton.aws.awssesconfigurationset.v1alpha1.AwsSesConfigurationSetEventDestination.event_bus -> AwsEventBridgeBus
 exempt    dev.planton.aws.awsvpcendpoint.v1alpha1.AwsVpcEndpointSpec.route_table_ids -> AwsSubnet
+exempt    dev.planton.azure.azureakscluster.v1alpha1.AzureAksClusterIngressApplicationGateway.subnet_id -> AzureSubnet
 exempt    dev.planton.azure.azureakscluster.v1alpha1.AzureAksClusterServiceMeshCertificateAuthority.key_vault_id -> AzureKeyVault
 exempt    dev.planton.azure.azureakscluster.v1alpha1.AzureAksClusterSpec.private_dns_zone_id -> AzurePrivateDnsZone
 exempt    dev.planton.azure.azureakscluster.v1alpha1.AzureAksClusterWebAppRouting.dns_zone_ids -> AzureDnsZone
+exempt    dev.planton.azure.azureaksnodepool.v1alpha1.AzureAksNodePoolSpec.pod_subnet_id -> AzureSubnet
+exempt    dev.planton.azure.azureaksnodepool.v1alpha1.AzureAksNodePoolSpec.vnet_subnet_id -> AzureSubnet
 exempt    dev.planton.azure.azurecontainerappenvironmentstorage.v1alpha1.AzureContainerAppEnvironmentStorageSpec.access_key -> AzureStorageAccount
 exempt    dev.planton.azure.azurecontainerappenvironmentstorage.v1alpha1.AzureContainerAppEnvironmentStorageSpec.account_name -> AzureStorageAccount
+exempt    dev.planton.azure.azurecontainerinstance.v1alpha1.AzureContainerInstanceVolumeAzureFile.storage_account_key -> AzureStorageAccount
+exempt    dev.planton.azure.azurecontainerinstance.v1alpha1.AzureContainerInstanceVolumeAzureFile.storage_account_name -> AzureStorageAccount
 exempt    dev.planton.azure.azurecosmosdbaccount.v1alpha1.AzureCosmosdbAccountVirtualNetworkRule.subnet_id -> AzureSubnet
+exempt    dev.planton.azure.azuredataprotectionbackupinstance.v1alpha1.AzureDataProtectionBackupInstanceKubernetesCluster.kubernetes_cluster_id -> AzureAksCluster
 exempt    dev.planton.azure.azureeventhub.v1alpha1.AzureEventHubCaptureDestination.storage_account_id -> AzureStorageAccount
 exempt    dev.planton.azure.azureeventhubdisasterrecoveryconfig.v1alpha1.AzureEventHubDisasterRecoveryConfigSpec.partner_namespace_id -> AzureEventHubNamespace
 exempt    dev.planton.azure.azureeventhubnamespace.v1alpha1.AzureEventHubNamespaceVirtualNetworkRule.subnet_id -> AzureSubnet


### PR DESCRIPTION
## Summary

Six references in the Azure container family are marked `containment_exempt`, because each names something the resource reaches, mounts, protects, or attaches to -- and lives somewhere else:

- `AzureContainerInstanceVolumeAzureFile.storage_account_name` and `.storage_account_key` -- a container group MOUNTS the share; it lives in its own resource group or subnet. The Container App environment's storage registration already carries the exemption on the identical pair of fields; the container group now agrees with it.
- `AzureDataProtectionBackupInstanceKubernetesCluster.kubernetes_cluster_id` -- a backup instance PROTECTS the cluster and lives in its vault.
- `AzureAksNodePoolSpec.vnet_subnet_id` and `.pod_subnet_id` -- a node pool is an ARM child of its cluster (`managedClusters/{cluster}/agentPools/{pool}`); the subnet is where its nodes attach. Without the exemption a pool on its own subnet (Azure's documented shape for segmenting an exposed pool or for dynamic pod IPs) names its cluster AND a subnet the cluster does not name, falls to a mixed-kind tie, and is drawn by topological luck on a project diagram and left floating outside its cluster on the organization estate.
- `AzureAksClusterIngressApplicationGateway.subnet_id` -- the add-on's Application Gateway lives in this subnet; the cluster does not, and was being promoted out of its own node subnet into the whole network.

The four Go stubs are regenerated with the pinned `protoc-gen-go v1.36.6` (comments and option bytes only). The containment golden moves exactly six lines `contained -> exempt`; nothing else moved. A `_changelog/2026-09/` note records the change.

## Test plan

- [x] `buf lint` and `buf format -d` clean on the four touched paths
- [x] `go test ./shared/cloudresourcekind/...` green; `-update` moved exactly the six lines above
- [x] Every `-run TestContainmentExemptTargetsContainerKinds` target is a container kind (`AzureStorageAccount`, `AzureAksCluster`, `AzureSubnet`)