### PR TITLE
fix(catalog/azure): what reaches into a Key Vault never lives in it, and a custom role lives where it is defined

### DIFF
--- a/_changelog/2026-09/2026-09-10-163000-what-reaches-into-a-key-vault-never-lives-in-it-and-a-role-lives-where-it-is-defined.md
+++ b/_changelog/2026-09/2026-09-10-163000-what-reaches-into-a-key-vault-never-lives-in-it-and-a-role-lives-where-it-is-defined.md
@@ -1,0 +1,18 @@
+# What reaches into a Key Vault never lives in it, and a custom role lives where it is defined
+
+## What changed
+
+- **Five Key Vault references are containment-exempt.** An AI Foundry hub stores its secrets in a vault and unwraps its encryption key through one (`AzureAiFoundrySpec.key_vault_id`, `AzureAiFoundryEncryption.key_vault_id`); a Machine Learning workspace does the same (`AzureMachineLearningWorkspaceSpec.key_vault_id`, `AzureMachineLearningWorkspaceEncryption.key_vault_id`); a Data Factory linked service of the Key Vault variant points at the vault other linked services resolve their secrets through (`AzureDataFactoryLinkedServiceKeyVault.key_vault_id`). Each of those resources WRITES INTO, UNWRAPS THROUGH, or POINTS AT the vault and lives somewhere else -- the hub and the workspace in their own resource group, the linked service in its factory -- so on a diagram every one of these references is access, not placement. The AKS cluster's service-mesh certificate authority, a virtual machine's and a scale set's vault-sourced secrets, and the External Secrets store's vault URL already carried the exemption; these five now agree with them. The references a key, a secret, and a certificate carry to their vault stay placement: those three ARE created inside it.
+- **A role definition's assignable scopes are containment-exempt.** `AzureRoleDefinitionSpec.assignable_scopes` lists WHERE a custom role may be granted; WHERE the definition itself lives is its `scope`, which stays placement. A definition assignable in two other resource groups was torn between three rooms.
+- The containment-decision registry (`shared/cloudresourcekind/testdata/containment_decisions.txt`) moves exactly six lines from `contained` to `exempt`. Nothing else moved.
+
+## Why
+
+`containment_exempt` says a reference into a container is access, not placement. Key Vault is a container kind (its keys, secrets, and certificates are created into it), so without the exemption a workspace, a hub, or a linked service that merely uses a vault would be drawn INSIDE it on a project diagram and on the organization estate -- and a diagram that puts a machine-learning workspace inside a Key Vault is confidently wrong about where things live. The vault stays on the picture as a line from each of them, which is what it is.
+
+## How to check
+
+```bash
+go test ./shared/cloudresourcekind/... -run TestContainmentDecisions   # green; the golden carries the six exemptions
+grep -n containment_exempt catalog/azure/azureaifoundry/v1alpha1/spec.proto catalog/azure/azuremachinelearningworkspace/v1alpha1/spec.proto catalog/azure/azuredatafactorylinkedservice/v1alpha1/spec.proto catalog/azure/azureroledefinition/v1alpha1/spec.proto
+```

--- a/catalog/azure/azureaifoundry/v1alpha1/spec.pb.go
+++ b/catalog/azure/azureaifoundry/v1alpha1/spec.pb.go
@@ -183,7 +183,9 @@ type AzureAiFoundrySpec struct {
 	// by the soft-deleted ghost until purged.
 	Name string `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty"`
 	// The Key Vault the hub stores its secrets in (connection
-	// credentials, project secrets), by ARM ID. Fixed at creation.
+	// credentials, project secrets), by ARM ID. Fixed at creation. The hub
+	// WRITES INTO the vault and lives in its own resource group, so the
+	// reference is access, not placement, on a diagram.
 	KeyVaultId *v1.StringValueOrRef `protobuf:"bytes,4,opt,name=key_vault_id,json=keyVaultId,proto3" json:"key_vault_id,omitempty"`
 	// The storage account backing the hub's artifacts and file shares,
 	// by ARM ID. Use a general-purpose account WITHOUT hierarchical
@@ -452,7 +454,9 @@ func (x *AzureAiFoundryIdentity) GetIdentityIds() []*v1.StringValueOrRef {
 // whole block is fixed at creation.
 type AzureAiFoundryEncryption struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// The Key Vault holding the encryption key, by ARM ID.
+	// The Key Vault holding the encryption key, by ARM ID. The hub UNWRAPS
+	// its key through the vault and never lives in it, so the reference is
+	// access, not placement, on a diagram.
 	KeyVaultId *v1.StringValueOrRef `protobuf:"bytes,1,opt,name=key_vault_id,json=keyVaultId,proto3" json:"key_vault_id,omitempty"`
 	// The Key Vault key as a VERSIONED data-plane URL
 	// ("https://{vault}.vault.azure.net/keys/{name}/{version}").
@@ -575,13 +579,13 @@ var File_catalog_azure_azureaifoundry_v1alpha1_spec_proto protoreflect.FileDescr
 
 const file_catalog_azure_azureaifoundry_v1alpha1_spec_proto_rawDesc = "" +
 	"\n" +
-	"0catalog/azure/azureaifoundry/v1alpha1/spec.proto\x12)dev.planton.azure.azureaifoundry.v1alpha1\x1a\x1bbuf/validate/validate.proto\x1a&shared/foreignkey/v1/foreign_key.proto\x1a\x1cshared/options/options.proto\"\xc4\r\n" +
+	"0catalog/azure/azureaifoundry/v1alpha1/spec.proto\x12)dev.planton.azure.azureaifoundry.v1alpha1\x1a\x1bbuf/validate/validate.proto\x1a&shared/foreignkey/v1/foreign_key.proto\x1a\x1cshared/options/options.proto\"\xc8\r\n" +
 	"\x12AzureAiFoundrySpec\x12\"\n" +
 	"\x06region\x18\x01 \x01(\tB\n" +
 	"\xbaH\a\xc8\x01\x01r\x02\x10\x01R\x06region\x12\x8c\x01\n" +
 	"\x0eresource_group\x18\x02 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB1\xbaH\x03\xc8\x01\x01\x88\xd4a\xd0\x0f\x92\xd4a\"status.outputs.resource_group_nameR\rresourceGroup\x12>\n" +
-	"\x04name\x18\x03 \x01(\tB*\xbaH'\xc8\x01\x01r\"2 ^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$R\x04name\x12\x80\x01\n" +
-	"\fkey_vault_id\x18\x04 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB*\xbaH\x03\xc8\x01\x01\x88\xd4a\xd5\x0f\x92\xd4a\x1bstatus.outputs.key_vault_idR\n" +
+	"\x04name\x18\x03 \x01(\tB*\xbaH'\xc8\x01\x01r\"2 ^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$R\x04name\x12\x84\x01\n" +
+	"\fkey_vault_id\x18\x04 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB.\xbaH\x03\xc8\x01\x01\x88\xd4a\xd5\x0f\x92\xd4a\x1bstatus.outputs.key_vault_id\x98\xd4a\x01R\n" +
 	"keyVaultId\x12\x92\x01\n" +
 	"\x12storage_account_id\x18\x05 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB0\xbaH\x03\xc8\x01\x01\x88\xd4a\xd9\x0f\x92\xd4a!status.outputs.storage_account_idR\x10storageAccountId\x12e\n" +
 	"\bidentity\x18\x06 \x01(\v2A.dev.planton.azure.azureaifoundry.v1alpha1.AzureAiFoundryIdentityB\x06\xbaH\x03\xc8\x01\x01R\bidentity\x12\x9b\x01\n" +
@@ -605,9 +609,9 @@ const file_catalog_azure_azureaifoundry_v1alpha1_spec_proto_rawDesc = "" +
 	"\x16AzureAiFoundryIdentity\x12a\n" +
 	"\x04type\x18\x01 \x01(\x0e2E.dev.planton.azure.azureaifoundry.v1alpha1.AzureAiFoundryIdentityTypeB\x06\xbaH\x03\xc8\x01\x01R\x04type\x12z\n" +
 	"\fidentity_ids\x18\x02 \x03(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB#\x88\xd4a\x8c\x10\x92\xd4a\x1astatus.outputs.identity_idR\videntityIds:\xf2\x01\xbaH\xee\x01\x1a\xeb\x01\n" +
-	"\x17identity_ids_match_type\x12midentity_ids is required for USER_ASSIGNED and SYSTEM_AND_USER_ASSIGNED and must be empty for SYSTEM_ASSIGNED\x1aa(this.type == 2 || this.type == 3) ? this.identity_ids.size() > 0 : this.identity_ids.size() == 0\"\xa3\x03\n" +
-	"\x18AzureAiFoundryEncryption\x12\x80\x01\n" +
-	"\fkey_vault_id\x18\x01 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB*\xbaH\x03\xc8\x01\x01\x88\xd4a\xd5\x0f\x92\xd4a\x1bstatus.outputs.key_vault_idR\n" +
+	"\x17identity_ids_match_type\x12midentity_ids is required for USER_ASSIGNED and SYSTEM_AND_USER_ASSIGNED and must be empty for SYSTEM_ASSIGNED\x1aa(this.type == 2 || this.type == 3) ? this.identity_ids.size() > 0 : this.identity_ids.size() == 0\"\xa7\x03\n" +
+	"\x18AzureAiFoundryEncryption\x12\x84\x01\n" +
+	"\fkey_vault_id\x18\x01 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB.\xbaH\x03\xc8\x01\x01\x88\xd4a\xd5\x0f\x92\xd4a\x1bstatus.outputs.key_vault_id\x98\xd4a\x01R\n" +
 	"keyVaultId\x12o\n" +
 	"\x06key_id\x18\x02 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB$\xbaH\x03\xc8\x01\x01\x88\xd4a\xe9\x0f\x92\xd4a\x15status.outputs.key_idR\x05keyId\x12\x92\x01\n" +
 	"\x19user_assigned_identity_id\x18\x03 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB#\x88\xd4a\x8c\x10\x92\xd4a\x1astatus.outputs.identity_idR\x16userAssignedIdentityId\"\x8d\x01\n" +

--- a/catalog/azure/azureaifoundry/v1alpha1/spec.proto
+++ b/catalog/azure/azureaifoundry/v1alpha1/spec.proto
@@ -58,10 +58,13 @@ message AzureAiFoundrySpec {
   ];
 
   // The Key Vault the hub stores its secrets in (connection
-  // credentials, project secrets), by ARM ID. Fixed at creation.
+  // credentials, project secrets), by ARM ID. Fixed at creation. The hub
+  // WRITES INTO the vault and lives in its own resource group, so the
+  // reference is access, not placement, on a diagram.
   dev.planton.shared.foreignkey.v1.StringValueOrRef key_vault_id = 4 [
     (buf.validate.field).required = true,
     (dev.planton.shared.foreignkey.v1.default_kind) = AzureKeyVault,
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true,
     (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.key_vault_id"
   ];
 
@@ -189,10 +192,13 @@ enum AzureAiFoundryIdentityType {
 // Customer-managed-key encryption for the hub's data at rest. The
 // whole block is fixed at creation.
 message AzureAiFoundryEncryption {
-  // The Key Vault holding the encryption key, by ARM ID.
+  // The Key Vault holding the encryption key, by ARM ID. The hub UNWRAPS
+  // its key through the vault and never lives in it, so the reference is
+  // access, not placement, on a diagram.
   dev.planton.shared.foreignkey.v1.StringValueOrRef key_vault_id = 1 [
     (buf.validate.field).required = true,
     (dev.planton.shared.foreignkey.v1.default_kind) = AzureKeyVault,
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true,
     (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.key_vault_id"
   ];
 

--- a/catalog/azure/azuredatafactorylinkedservice/v1alpha1/spec.pb.go
+++ b/catalog/azure/azuredatafactorylinkedservice/v1alpha1/spec.pb.go
@@ -1725,7 +1725,9 @@ type AzureDataFactoryLinkedServiceKeyVault struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The Key Vault, by ARM ID -- defaults to referencing an
 	// AzureKeyVault's key_vault_id output. The modules derive the
-	// vault's base URI from it, exactly as the provider does.
+	// vault's base URI from it, exactly as the provider does. A linked
+	// service POINTS AT the vault and lives in its factory, so the
+	// reference is access, not placement, on a diagram.
 	KeyVaultId    *v1.StringValueOrRef `protobuf:"bytes,1,opt,name=key_vault_id,json=keyVaultId,proto3" json:"key_vault_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -2815,9 +2817,9 @@ const file_catalog_azure_azuredatafactorylinkedservice_v1alpha1_spec_proto_rawDe
 	"\x06tenant\x18\x06 \x01(\tR\x06tenant:\xec\x04\xbaH\xe8\x04\x1a\xfc\x02\n" +
 	"1data_factory_linked_service_gen2_exactly_one_auth\x12\xa0\x01Set exactly one authentication mode -- use_managed_identity, storage_account_key, or a service principal (service_principal_id + service_principal_key + tenant)\x1a\xa3\x01((has(this.use_managed_identity) && this.use_managed_identity) ? 1 : 0) + (this.storage_account_key != '' ? 1 : 0) + (this.service_principal_id != '' ? 1 : 0) == 1\x1a\xe6\x01\n" +
 	",data_factory_linked_service_gen2_sp_complete\x12ZA service principal needs service_principal_id, service_principal_key, and tenant together\x1aZthis.service_principal_id == '' || (this.service_principal_key != '' && this.tenant != '')B\x17\n" +
-	"\x15_use_managed_identity\"\xaa\x01\n" +
-	"%AzureDataFactoryLinkedServiceKeyVault\x12\x80\x01\n" +
-	"\fkey_vault_id\x18\x01 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB*\xbaH\x03\xc8\x01\x01\x88\xd4a\xd5\x0f\x92\xd4a\x1bstatus.outputs.key_vault_idR\n" +
+	"\x15_use_managed_identity\"\xae\x01\n" +
+	"%AzureDataFactoryLinkedServiceKeyVault\x12\x84\x01\n" +
+	"\fkey_vault_id\x18\x01 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB.\xbaH\x03\xc8\x01\x01\x88\xd4a\xd5\x0f\x92\xd4a\x1bstatus.outputs.key_vault_id\x98\xd4a\x01R\n" +
 	"keyVaultId\"\x94\t\n" +
 	"\"AzureDataFactoryLinkedServiceKusto\x12-\n" +
 	"\x0ekusto_endpoint\x18\x01 \x01(\tB\x06\xbaH\x03\xc8\x01\x01R\rkustoEndpoint\x126\n" +

--- a/catalog/azure/azuredatafactorylinkedservice/v1alpha1/spec.proto
+++ b/catalog/azure/azuredatafactorylinkedservice/v1alpha1/spec.proto
@@ -733,10 +733,13 @@ message AzureDataFactoryLinkedServiceDataLakeStorageGen2 {
 message AzureDataFactoryLinkedServiceKeyVault {
   // The Key Vault, by ARM ID -- defaults to referencing an
   // AzureKeyVault's key_vault_id output. The modules derive the
-  // vault's base URI from it, exactly as the provider does.
+  // vault's base URI from it, exactly as the provider does. A linked
+  // service POINTS AT the vault and lives in its factory, so the
+  // reference is access, not placement, on a diagram.
   dev.planton.shared.foreignkey.v1.StringValueOrRef key_vault_id = 1 [
     (buf.validate.field).required = true,
     (dev.planton.shared.foreignkey.v1.default_kind) = AzureKeyVault,
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true,
     (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.key_vault_id"
   ];
 }

--- a/catalog/azure/azuremachinelearningworkspace/v1alpha1/spec.pb.go
+++ b/catalog/azure/azuremachinelearningworkspace/v1alpha1/spec.pb.go
@@ -298,7 +298,9 @@ type AzureMachineLearningWorkspaceSpec struct {
 	// to, by ARM ID. Fixed at creation.
 	ApplicationInsightsId *v1.StringValueOrRef `protobuf:"bytes,4,opt,name=application_insights_id,json=applicationInsightsId,proto3" json:"application_insights_id,omitempty"`
 	// The Key Vault the workspace stores its secrets in (connection
-	// credentials, compute SSH keys), by ARM ID. Fixed at creation.
+	// credentials, compute SSH keys), by ARM ID. Fixed at creation. The
+	// workspace WRITES INTO the vault and lives in its own resource group,
+	// so the reference is access, not placement, on a diagram.
 	KeyVaultId *v1.StringValueOrRef `protobuf:"bytes,5,opt,name=key_vault_id,json=keyVaultId,proto3" json:"key_vault_id,omitempty"`
 	// The storage account backing the workspace's artifacts and its two
 	// built-in datastores, by ARM ID. Must be a general-purpose account
@@ -770,7 +772,9 @@ func (x *AzureMachineLearningWorkspaceFeatureStore) GetOnlineConnectionName() st
 // The whole block is fixed at creation.
 type AzureMachineLearningWorkspaceEncryption struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// The Key Vault holding the encryption key, by ARM ID.
+	// The Key Vault holding the encryption key, by ARM ID. The workspace
+	// UNWRAPS its key through the vault and never lives in it, so the
+	// reference is access, not placement, on a diagram.
 	KeyVaultId *v1.StringValueOrRef `protobuf:"bytes,1,opt,name=key_vault_id,json=keyVaultId,proto3" json:"key_vault_id,omitempty"`
 	// The Key Vault key (data-plane URL, e.g.
 	// "https://{vault}.vault.azure.net/keys/{name}"). Reference an
@@ -1186,14 +1190,14 @@ var File_catalog_azure_azuremachinelearningworkspace_v1alpha1_spec_proto protore
 
 const file_catalog_azure_azuremachinelearningworkspace_v1alpha1_spec_proto_rawDesc = "" +
 	"\n" +
-	"?catalog/azure/azuremachinelearningworkspace/v1alpha1/spec.proto\x128dev.planton.azure.azuremachinelearningworkspace.v1alpha1\x1a\x1bbuf/validate/validate.proto\x1a&shared/foreignkey/v1/foreign_key.proto\x1a\x1cshared/options/options.proto\"\x90\"\n" +
+	"?catalog/azure/azuremachinelearningworkspace/v1alpha1/spec.proto\x128dev.planton.azure.azuremachinelearningworkspace.v1alpha1\x1a\x1bbuf/validate/validate.proto\x1a&shared/foreignkey/v1/foreign_key.proto\x1a\x1cshared/options/options.proto\"\x94\"\n" +
 	"!AzureMachineLearningWorkspaceSpec\x12\"\n" +
 	"\x06region\x18\x01 \x01(\tB\n" +
 	"\xbaH\a\xc8\x01\x01r\x02\x10\x01R\x06region\x12\x8c\x01\n" +
 	"\x0eresource_group\x18\x02 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB1\xbaH\x03\xc8\x01\x01\x88\xd4a\xd0\x0f\x92\xd4a\"status.outputs.resource_group_nameR\rresourceGroup\x12>\n" +
 	"\x04name\x18\x03 \x01(\tB*\xbaH'\xc8\x01\x01r\"2 ^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$R\x04name\x12\xa1\x01\n" +
-	"\x17application_insights_id\x18\x04 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB5\xbaH\x03\xc8\x01\x01\x88\xd4a\x83\x10\x92\xd4a&status.outputs.application_insights_idR\x15applicationInsightsId\x12\x80\x01\n" +
-	"\fkey_vault_id\x18\x05 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB*\xbaH\x03\xc8\x01\x01\x88\xd4a\xd5\x0f\x92\xd4a\x1bstatus.outputs.key_vault_idR\n" +
+	"\x17application_insights_id\x18\x04 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB5\xbaH\x03\xc8\x01\x01\x88\xd4a\x83\x10\x92\xd4a&status.outputs.application_insights_idR\x15applicationInsightsId\x12\x84\x01\n" +
+	"\fkey_vault_id\x18\x05 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB.\xbaH\x03\xc8\x01\x01\x88\xd4a\xd5\x0f\x92\xd4a\x1bstatus.outputs.key_vault_id\x98\xd4a\x01R\n" +
 	"keyVaultId\x12\x92\x01\n" +
 	"\x12storage_account_id\x18\x06 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB0\xbaH\x03\xc8\x01\x01\x88\xd4a\xd9\x0f\x92\xd4a!status.outputs.storage_account_idR\x10storageAccountId\x12\x83\x01\n" +
 	"\bidentity\x18\a \x01(\v2_.dev.planton.azure.azuremachinelearningworkspace.v1alpha1.AzureMachineLearningWorkspaceIdentityB\x06\xbaH\x03\xc8\x01\x01R\bidentity\x12o\n" +
@@ -1236,9 +1240,9 @@ const file_catalog_azure_azuremachinelearningworkspace_v1alpha1_spec_proto_rawDe
 	")AzureMachineLearningWorkspaceFeatureStore\x12C\n" +
 	"\x1ecomputer_spark_runtime_version\x18\x01 \x01(\tR\x1bcomputerSparkRuntimeVersion\x126\n" +
 	"\x17offline_connection_name\x18\x02 \x01(\tR\x15offlineConnectionName\x124\n" +
-	"\x16online_connection_name\x18\x03 \x01(\tR\x14onlineConnectionName\"\xba\x03\n" +
-	"'AzureMachineLearningWorkspaceEncryption\x12\x80\x01\n" +
-	"\fkey_vault_id\x18\x01 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB*\xbaH\x03\xc8\x01\x01\x88\xd4a\xd5\x0f\x92\xd4a\x1bstatus.outputs.key_vault_idR\n" +
+	"\x16online_connection_name\x18\x03 \x01(\tR\x14onlineConnectionName\"\xbe\x03\n" +
+	"'AzureMachineLearningWorkspaceEncryption\x12\x84\x01\n" +
+	"\fkey_vault_id\x18\x01 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB.\xbaH\x03\xc8\x01\x01\x88\xd4a\xd5\x0f\x92\xd4a\x1bstatus.outputs.key_vault_id\x98\xd4a\x01R\n" +
 	"keyVaultId\x12w\n" +
 	"\x06key_id\x18\x02 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB,\xbaH\x03\xc8\x01\x01\x88\xd4a\xe9\x0f\x92\xd4a\x1dstatus.outputs.versionless_idR\x05keyId\x12\x92\x01\n" +
 	"\x19user_assigned_identity_id\x18\x03 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB#\x88\xd4a\x8c\x10\x92\xd4a\x1astatus.outputs.identity_idR\x16userAssignedIdentityId\"\xfe\x01\n" +

--- a/catalog/azure/azuremachinelearningworkspace/v1alpha1/spec.proto
+++ b/catalog/azure/azuremachinelearningworkspace/v1alpha1/spec.proto
@@ -68,10 +68,13 @@ message AzureMachineLearningWorkspaceSpec {
   ];
 
   // The Key Vault the workspace stores its secrets in (connection
-  // credentials, compute SSH keys), by ARM ID. Fixed at creation.
+  // credentials, compute SSH keys), by ARM ID. Fixed at creation. The
+  // workspace WRITES INTO the vault and lives in its own resource group,
+  // so the reference is access, not placement, on a diagram.
   dev.planton.shared.foreignkey.v1.StringValueOrRef key_vault_id = 5 [
     (buf.validate.field).required = true,
     (dev.planton.shared.foreignkey.v1.default_kind) = AzureKeyVault,
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true,
     (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.key_vault_id"
   ];
 
@@ -329,10 +332,13 @@ message AzureMachineLearningWorkspaceFeatureStore {
 // Customer-managed-key encryption for the workspace's data at rest.
 // The whole block is fixed at creation.
 message AzureMachineLearningWorkspaceEncryption {
-  // The Key Vault holding the encryption key, by ARM ID.
+  // The Key Vault holding the encryption key, by ARM ID. The workspace
+  // UNWRAPS its key through the vault and never lives in it, so the
+  // reference is access, not placement, on a diagram.
   dev.planton.shared.foreignkey.v1.StringValueOrRef key_vault_id = 1 [
     (buf.validate.field).required = true,
     (dev.planton.shared.foreignkey.v1.default_kind) = AzureKeyVault,
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true,
     (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.key_vault_id"
   ];
 

--- a/catalog/azure/azureroledefinition/v1alpha1/spec.pb.go
+++ b/catalog/azure/azureroledefinition/v1alpha1/spec.pb.go
@@ -117,7 +117,9 @@ type AzureRoleDefinitionSpec struct {
 	//
 	// Each entry is a literal ARM ID or a reference to a resource's ID output
 	// (defaults to an AzureResourceGroup's ARM ID); literals and references
-	// can mix freely. Updatable in place.
+	// can mix freely. Updatable in place. Where a role MAY BE ASSIGNED is not
+	// where the definition lives (that is `scope`), so on a diagram these
+	// references are access, not placement.
 	AssignableScopes []*v1.StringValueOrRef `protobuf:"bytes,5,rep,name=assignable_scopes,json=assignableScopes,proto3" json:"assignable_scopes,omitempty"`
 	// A stable UUID for the role definition's ARM resource name. Azure
 	// identifies a role definition by a GUID; when omitted (recommended), a
@@ -310,14 +312,14 @@ var File_catalog_azure_azureroledefinition_v1alpha1_spec_proto protoreflect.File
 
 const file_catalog_azure_azureroledefinition_v1alpha1_spec_proto_rawDesc = "" +
 	"\n" +
-	"5catalog/azure/azureroledefinition/v1alpha1/spec.proto\x12.dev.planton.azure.azureroledefinition.v1alpha1\x1a\x1bbuf/validate/validate.proto\x1a&shared/foreignkey/v1/foreign_key.proto\"\x8f\x04\n" +
+	"5catalog/azure/azureroledefinition/v1alpha1/spec.proto\x12.dev.planton.azure.azureroledefinition.v1alpha1\x1a\x1bbuf/validate/validate.proto\x1a&shared/foreignkey/v1/foreign_key.proto\"\x93\x04\n" +
 	"\x17AzureRoleDefinitionSpec\x12\x1e\n" +
 	"\x04name\x18\x01 \x01(\tB\n" +
 	"\xbaH\a\xc8\x01\x01r\x02\x10\x01R\x04name\x12y\n" +
 	"\x05scope\x18\x02 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB/\xbaH\x03\xc8\x01\x01\x88\xd4a\xd0\x0f\x92\xd4a status.outputs.resource_group_idR\x05scope\x12 \n" +
 	"\vdescription\x18\x03 \x01(\tR\vdescription\x12o\n" +
-	"\vpermissions\x18\x04 \x03(\v2M.dev.planton.azure.azureroledefinition.v1alpha1.AzureRoleDefinitionPermissionR\vpermissions\x12\x8a\x01\n" +
-	"\x11assignable_scopes\x18\x05 \x03(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB)\x88\xd4a\xd0\x0f\x92\xd4a status.outputs.resource_group_idR\x10assignableScopes\x129\n" +
+	"\vpermissions\x18\x04 \x03(\v2M.dev.planton.azure.azureroledefinition.v1alpha1.AzureRoleDefinitionPermissionR\vpermissions\x12\x8e\x01\n" +
+	"\x11assignable_scopes\x18\x05 \x03(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB-\x88\xd4a\xd0\x0f\x92\xd4a status.outputs.resource_group_id\x98\xd4a\x01R\x10assignableScopes\x129\n" +
 	"\x12role_definition_id\x18\x06 \x01(\tB\v\xbaH\b\xd8\x01\x01r\x03\xb0\x01\x01R\x10roleDefinitionId\"\xa7\x01\n" +
 	"\x1dAzureRoleDefinitionPermission\x12\x18\n" +
 	"\aactions\x18\x01 \x03(\tR\aactions\x12\x1f\n" +

--- a/catalog/azure/azureroledefinition/v1alpha1/spec.proto
+++ b/catalog/azure/azureroledefinition/v1alpha1/spec.proto
@@ -108,9 +108,12 @@ message AzureRoleDefinitionSpec {
   //
   // Each entry is a literal ARM ID or a reference to a resource's ID output
   // (defaults to an AzureResourceGroup's ARM ID); literals and references
-  // can mix freely. Updatable in place.
+  // can mix freely. Updatable in place. Where a role MAY BE ASSIGNED is not
+  // where the definition lives (that is `scope`), so on a diagram these
+  // references are access, not placement.
   repeated dev.planton.shared.foreignkey.v1.StringValueOrRef assignable_scopes = 5 [
     (dev.planton.shared.foreignkey.v1.default_kind) = AzureResourceGroup,
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true,
     (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.resource_group_id"
   ];
 

--- a/shared/cloudresourcekind/testdata/containment_decisions.txt
+++ b/shared/cloudresourcekind/testdata/containment_decisions.txt
@@ -110,8 +110,6 @@ contained dev.planton.aws.awsvpcendpoint.v1alpha1.AwsVpcEndpointSpec.vpc_id -> A
 contained dev.planton.aws.awsvpcendpoint.v1alpha1.AwsVpcEndpointSubnetConfiguration.subnet_id -> AwsSubnet
 contained dev.planton.aws.awsvpcpeering.v1alpha1.AwsVpcPeeringRequest.peer_vpc_id -> AwsVpc
 contained dev.planton.aws.awsvpcpeering.v1alpha1.AwsVpcPeeringRequest.vpc_id -> AwsVpc
-contained dev.planton.azure.azureaifoundry.v1alpha1.AzureAiFoundryEncryption.key_vault_id -> AzureKeyVault
-contained dev.planton.azure.azureaifoundry.v1alpha1.AzureAiFoundrySpec.key_vault_id -> AzureKeyVault
 contained dev.planton.azure.azureaifoundry.v1alpha1.AzureAiFoundrySpec.resource_group -> AzureResourceGroup
 contained dev.planton.azure.azureaifoundry.v1alpha1.AzureAiFoundrySpec.storage_account_id -> AzureStorageAccount
 contained dev.planton.azure.azureakscluster.v1alpha1.AzureAksClusterApiServerAccessProfile.subnet_id -> AzureSubnet
@@ -176,7 +174,6 @@ contained dev.planton.azure.azuredatafactoryintegrationruntime.v1alpha1.AzureDat
 contained dev.planton.azure.azuredatafactoryintegrationruntime.v1alpha1.AzureDataFactoryIntegrationRuntimeSsisVnetIntegration.vnet_id -> AzureVirtualNetwork
 contained dev.planton.azure.azuredatafactorylinkedservice.v1alpha1.AzureDataFactoryLinkedServiceAzureBlobStorage.service_endpoint -> AzureStorageAccount
 contained dev.planton.azure.azuredatafactorylinkedservice.v1alpha1.AzureDataFactoryLinkedServiceDataLakeStorageGen2.url -> AzureStorageAccount
-contained dev.planton.azure.azuredatafactorylinkedservice.v1alpha1.AzureDataFactoryLinkedServiceKeyVault.key_vault_id -> AzureKeyVault
 contained dev.planton.azure.azuredatafactorytrigger.v1alpha1.AzureDataFactoryTriggerBlobEvent.storage_account_id -> AzureStorageAccount
 contained dev.planton.azure.azuredataprotectionbackupinstance.v1alpha1.AzureDataProtectionBackupInstanceBlobStorage.storage_account_id -> AzureStorageAccount
 contained dev.planton.azure.azuredataprotectionbackupinstance.v1alpha1.AzureDataProtectionBackupInstanceDataLakeStorage.storage_account_id -> AzureStorageAccount
@@ -244,9 +241,7 @@ contained dev.planton.azure.azurelocalnetworkgateway.v1alpha1.AzureLocalNetworkG
 contained dev.planton.azure.azureloganalyticsworkspace.v1alpha1.AzureLogAnalyticsWorkspaceSpec.resource_group -> AzureResourceGroup
 contained dev.planton.azure.azuremachinelearningcomputecluster.v1alpha1.AzureMachineLearningComputeClusterSpec.subnet_id -> AzureSubnet
 contained dev.planton.azure.azuremachinelearningcomputeinstance.v1alpha1.AzureMachineLearningComputeInstanceSpec.subnet_id -> AzureSubnet
-contained dev.planton.azure.azuremachinelearningworkspace.v1alpha1.AzureMachineLearningWorkspaceEncryption.key_vault_id -> AzureKeyVault
 contained dev.planton.azure.azuremachinelearningworkspace.v1alpha1.AzureMachineLearningWorkspaceServerlessCompute.subnet_id -> AzureSubnet
-contained dev.planton.azure.azuremachinelearningworkspace.v1alpha1.AzureMachineLearningWorkspaceSpec.key_vault_id -> AzureKeyVault
 contained dev.planton.azure.azuremachinelearningworkspace.v1alpha1.AzureMachineLearningWorkspaceSpec.resource_group -> AzureResourceGroup
 contained dev.planton.azure.azuremachinelearningworkspace.v1alpha1.AzureMachineLearningWorkspaceSpec.storage_account_id -> AzureStorageAccount
 contained dev.planton.azure.azuremanageddisk.v1alpha1.AzureManagedDiskSpec.resource_group -> AzureResourceGroup
@@ -296,7 +291,6 @@ contained dev.planton.azure.azurerecoveryservicesvault.v1alpha1.AzureRecoverySer
 contained dev.planton.azure.azurerediscache.v1alpha1.AzureRedisCacheSpec.resource_group -> AzureResourceGroup
 contained dev.planton.azure.azurerediscache.v1alpha1.AzureRedisCacheSpec.subnet_id -> AzureSubnet
 contained dev.planton.azure.azureroleassignment.v1alpha1.AzureRoleAssignmentSpec.scope -> AzureResourceGroup
-contained dev.planton.azure.azureroledefinition.v1alpha1.AzureRoleDefinitionSpec.assignable_scopes -> AzureResourceGroup
 contained dev.planton.azure.azureroledefinition.v1alpha1.AzureRoleDefinitionSpec.scope -> AzureResourceGroup
 contained dev.planton.azure.azureroutetable.v1alpha1.AzureRouteTableSpec.resource_group -> AzureResourceGroup
 contained dev.planton.azure.azuresearchservice.v1alpha1.AzureSearchServiceSpec.resource_group -> AzureResourceGroup
@@ -682,12 +676,15 @@ exempt    dev.planton.aws.awsroute53zone.v1alpha1.AwsRoute53ZoneVpcAssociation.v
 exempt    dev.planton.aws.awssagemakerdomain.v1alpha1.AwsSagemakerDomainEfsFileSystemConfig.file_system_id -> AwsElasticFileSystem
 exempt    dev.planton.aws.awssesconfigurationset.v1alpha1.AwsSesConfigurationSetEventDestination.event_bus -> AwsEventBridgeBus
 exempt    dev.planton.aws.awsvpcendpoint.v1alpha1.AwsVpcEndpointSpec.route_table_ids -> AwsSubnet
+exempt    dev.planton.azure.azureaifoundry.v1alpha1.AzureAiFoundryEncryption.key_vault_id -> AzureKeyVault
+exempt    dev.planton.azure.azureaifoundry.v1alpha1.AzureAiFoundrySpec.key_vault_id -> AzureKeyVault
 exempt    dev.planton.azure.azureakscluster.v1alpha1.AzureAksClusterServiceMeshCertificateAuthority.key_vault_id -> AzureKeyVault
 exempt    dev.planton.azure.azureakscluster.v1alpha1.AzureAksClusterSpec.private_dns_zone_id -> AzurePrivateDnsZone
 exempt    dev.planton.azure.azureakscluster.v1alpha1.AzureAksClusterWebAppRouting.dns_zone_ids -> AzureDnsZone
 exempt    dev.planton.azure.azurecontainerappenvironmentstorage.v1alpha1.AzureContainerAppEnvironmentStorageSpec.access_key -> AzureStorageAccount
 exempt    dev.planton.azure.azurecontainerappenvironmentstorage.v1alpha1.AzureContainerAppEnvironmentStorageSpec.account_name -> AzureStorageAccount
 exempt    dev.planton.azure.azurecosmosdbaccount.v1alpha1.AzureCosmosdbAccountVirtualNetworkRule.subnet_id -> AzureSubnet
+exempt    dev.planton.azure.azuredatafactorylinkedservice.v1alpha1.AzureDataFactoryLinkedServiceKeyVault.key_vault_id -> AzureKeyVault
 exempt    dev.planton.azure.azureeventhub.v1alpha1.AzureEventHubCaptureDestination.storage_account_id -> AzureStorageAccount
 exempt    dev.planton.azure.azureeventhubdisasterrecoveryconfig.v1alpha1.AzureEventHubDisasterRecoveryConfigSpec.partner_namespace_id -> AzureEventHubNamespace
 exempt    dev.planton.azure.azureeventhubnamespace.v1alpha1.AzureEventHubNamespaceVirtualNetworkRule.subnet_id -> AzureSubnet
@@ -709,6 +706,8 @@ exempt    dev.planton.azure.azurelinuxwebapp.v1alpha1.AzureLinuxWebAppIpRestrict
 exempt    dev.planton.azure.azurelinuxwebapp.v1alpha1.AzureLinuxWebAppIpRestrictionHeaders.x_azure_fdid -> AzureFrontDoorProfile
 exempt    dev.planton.azure.azurelinuxwebapp.v1alpha1.AzureLinuxWebAppSpec.virtual_network_subnet_id -> AzureSubnet
 exempt    dev.planton.azure.azurelinuxwebapp.v1alpha1.AzureLinuxWebAppStorageMount.access_key -> AzureStorageAccount
+exempt    dev.planton.azure.azuremachinelearningworkspace.v1alpha1.AzureMachineLearningWorkspaceEncryption.key_vault_id -> AzureKeyVault
+exempt    dev.planton.azure.azuremachinelearningworkspace.v1alpha1.AzureMachineLearningWorkspaceSpec.key_vault_id -> AzureKeyVault
 exempt    dev.planton.azure.azuremonitoractiongroup.v1alpha1.AzureMonitorActionGroupEventHubReceiver.event_hub_name -> AzureEventHub
 exempt    dev.planton.azure.azuremonitoractiongroup.v1alpha1.AzureMonitorActionGroupEventHubReceiver.event_hub_namespace -> AzureEventHubNamespace
 exempt    dev.planton.azure.azuremonitoractivitylogalert.v1alpha1.AzureMonitorActivityLogAlertSpec.scopes -> AzureResourceGroup
@@ -721,6 +720,7 @@ exempt    dev.planton.azure.azureprivatednsresolver.v1alpha1.AzurePrivateDnsReso
 exempt    dev.planton.azure.azureprivatednsresolvervirtualnetworklink.v1alpha1.AzurePrivateDnsResolverVirtualNetworkLinkSpec.virtual_network_id -> AzureVirtualNetwork
 exempt    dev.planton.azure.azureprivatednszonevirtualnetworklink.v1alpha1.AzurePrivateDnsZoneVirtualNetworkLinkSpec.virtual_network_id -> AzureVirtualNetwork
 exempt    dev.planton.azure.azureprivateendpoint.v1alpha1.AzurePrivateEndpointSpec.private_dns_zone_ids -> AzurePrivateDnsZone
+exempt    dev.planton.azure.azureroledefinition.v1alpha1.AzureRoleDefinitionSpec.assignable_scopes -> AzureResourceGroup
 exempt    dev.planton.azure.azureservicebusdisasterrecoveryconfig.v1alpha1.AzureServiceBusDisasterRecoveryConfigSpec.partner_namespace_id -> AzureServiceBusNamespace
 exempt    dev.planton.azure.azureservicebusnamespace.v1alpha1.AzureServiceBusNamespaceNetworkRule.subnet_id -> AzureSubnet
 exempt    dev.planton.azure.azurestorageaccount.v1alpha1.AzureStorageAccountNetworkRules.virtual_network_subnet_ids -> AzureSubnet


### PR DESCRIPTION
## Summary

- **Five Key Vault references become access, not placement.** An AI Foundry hub's secrets vault and encryption vault, a Machine Learning workspace's secrets vault and encryption vault, and a Data Factory Key Vault linked service's vault all gain `containment_exempt`. Each of those resources writes into, unwraps through, or points at the vault and lives somewhere else; without the exemption a diagram would draw a machine-learning workspace *inside* a Key Vault. The AKS service-mesh CA, the VM and scale-set vault secrets, and the External Secrets store's vault URL already carried the exemption; these five now agree with them. A key, a secret, and a certificate keep their placement: those three ARE created inside the vault.
- **A role definition's `assignable_scopes` become access.** Where a custom role may be granted is not where the definition lives (that is its `scope`, unchanged); a definition assignable in two other resource groups was torn between three rooms.
- The four Go stubs are regenerated with the pinned `protoc-gen-go v1.36.6` (comments and option bytes only). The containment golden moves exactly six lines `contained -> exempt` and nothing else.

Same class as #537, #540, and #541: a reference that reaches into a room is not a residence in it.

## Test plan

- [x] `buf lint` and `buf format -d` clean on the four touched paths
- [x] `go test ./shared/cloudresourcekind/...` green; the golden diff is exactly six lines, each attributed above
- [x] Stub diff reviewed: comment text and the option bytes on the six fields, nothing else