### PR TITLE
fix(catalog/azure): a SQL failover group lives on its primary and a Cosmos DB role lives in its account on a diagram

### DIFF
--- a/_changelog/2026-09/2026-09-11-104500-a-failover-group-lives-on-its-primary-and-a-cosmos-role-lives-in-its-account.md
+++ b/_changelog/2026-09/2026-09-11-104500-a-failover-group-lives-on-its-primary-and-a-cosmos-role-lives-in-its-account.md
@@ -1,0 +1,18 @@
+# A failover group lives on its primary, and a Cosmos DB role lives in its account
+
+## What changed
+
+- **A SQL failover group's partner server is containment-exempt.** `AzureMssqlFailoverGroupPartnerServer.server_id` names the secondary server the group replicates databases TO. The group is created ON its primary (`AzureMssqlFailoverGroupSpec.server_id`, which stays placement) and points at the partner, so on a diagram the partner reference is access, not placement. Before this change both references were placement, and a group naming two servers of the same kind was promoted to the room they share -- the resource group beside both servers, or nothing at all when the partner lives in another group -- instead of standing on its primary.
+- **A Cosmos DB SQL role definition's assignable scopes are containment-exempt.** `AzureCosmosdbSqlRoleDefinitionSpec.assignable_scopes` lists WHERE a custom data-plane role may be granted; WHERE the definition itself lives is its `cosmosdb_account_id`, which stays placement. The same rule the subscription-level `AzureRoleDefinitionSpec.assignable_scopes` already carries.
+- The containment-decision registry (`shared/cloudresourcekind/testdata/containment_decisions.txt`) moves exactly two lines from `contained` to `exempt`. Nothing else moved.
+
+## Why
+
+`containment_exempt` says a reference into a container is access, not placement. `AzureMssqlServer` and `AzureCosmosdbAccount` are container kinds (databases, pools, and roles are created into them), so without the exemption a failover group would be drawn beside its servers instead of on the primary it is anchored to, and a role definition whose scopes are authored into a database would be drawn inside that database instead of in the account that owns it. The partner server and the assignable scopes stay on the picture as lines, which is what they are.
+
+## How to check
+
+```bash
+go test ./shared/cloudresourcekind/... -run TestContainmentDecisions   # green; the golden carries the two exemptions
+grep -n containment_exempt catalog/azure/azuremssqlfailovergroup/v1alpha1/spec.proto catalog/azure/azurecosmosdbsqlroledefinition/v1alpha1/spec.proto
+```

--- a/catalog/azure/azurecosmosdbsqlroledefinition/v1alpha1/spec.pb.go
+++ b/catalog/azure/azurecosmosdbsqlroledefinition/v1alpha1/spec.pb.go
@@ -152,6 +152,10 @@ type AzureCosmosdbSqlRoleDefinitionSpec struct {
 	//
 	//	assignableScopes:
 	//	  - value: /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.DocumentDB/databaseAccounts/{account}/dbs/app-data
+	//
+	// Where a role MAY BE ASSIGNED is not where the definition lives (that is
+	// `cosmosdb_account_id`), so on a diagram these references are access,
+	// not placement.
 	AssignableScopes []*v1.StringValueOrRef `protobuf:"bytes,4,rep,name=assignable_scopes,json=assignableScopes,proto3" json:"assignable_scopes,omitempty"`
 	// The permission blocks defining what this role allows. Azure evaluates
 	// them as a union: an operation is permitted if any block's data actions
@@ -315,13 +319,13 @@ var File_catalog_azure_azurecosmosdbsqlroledefinition_v1alpha1_spec_proto protor
 
 const file_catalog_azure_azurecosmosdbsqlroledefinition_v1alpha1_spec_proto_rawDesc = "" +
 	"\n" +
-	"@catalog/azure/azurecosmosdbsqlroledefinition/v1alpha1/spec.proto\x129dev.planton.azure.azurecosmosdbsqlroledefinition.v1alpha1\x1a\x1bbuf/validate/validate.proto\x1a&shared/foreignkey/v1/foreign_key.proto\"\xbc\x05\n" +
+	"@catalog/azure/azurecosmosdbsqlroledefinition/v1alpha1/spec.proto\x129dev.planton.azure.azurecosmosdbsqlroledefinition.v1alpha1\x1a\x1bbuf/validate/validate.proto\x1a&shared/foreignkey/v1/foreign_key.proto\"\xc0\x05\n" +
 	"\"AzureCosmosdbSqlRoleDefinitionSpec\x12\x95\x01\n" +
 	"\x13cosmosdb_account_id\x18\x01 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB1\xbaH\x03\xc8\x01\x01\x88\xd4a\xf0\x0f\x92\xd4a\"status.outputs.cosmosdb_account_idR\x11cosmosdbAccountId\x12'\n" +
 	"\trole_name\x18\x02 \x01(\tB\n" +
 	"\xbaH\a\xc8\x01\x01r\x02\x10\x01R\broleName\x12q\n" +
-	"\x04type\x18\x03 \x01(\x0e2].dev.planton.azure.azurecosmosdbsqlroledefinition.v1alpha1.AzureCosmosdbSqlRoleDefinitionTypeR\x04type\x12\x94\x01\n" +
-	"\x11assignable_scopes\x18\x04 \x03(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB3\xbaH\x05\x92\x01\x02\b\x01\x88\xd4a\xf0\x0f\x92\xd4a\"status.outputs.cosmosdb_account_idR\x10assignableScopes\x12\x8f\x01\n" +
+	"\x04type\x18\x03 \x01(\x0e2].dev.planton.azure.azurecosmosdbsqlroledefinition.v1alpha1.AzureCosmosdbSqlRoleDefinitionTypeR\x04type\x12\x98\x01\n" +
+	"\x11assignable_scopes\x18\x04 \x03(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB7\xbaH\x05\x92\x01\x02\b\x01\x88\xd4a\xf0\x0f\x92\xd4a\"status.outputs.cosmosdb_account_id\x98\xd4a\x01R\x10assignableScopes\x12\x8f\x01\n" +
 	"\vpermissions\x18\x05 \x03(\v2c.dev.planton.azure.azurecosmosdbsqlroledefinition.v1alpha1.AzureCosmosdbSqlRoleDefinitionPermissionB\b\xbaH\x05\x92\x01\x02\b\x01R\vpermissions\x129\n" +
 	"\x12role_definition_id\x18\x06 \x01(\tB\v\xbaH\b\xd8\x01\x01r\x03\xb0\x01\x01R\x10roleDefinitionId\"]\n" +
 	"(AzureCosmosdbSqlRoleDefinitionPermission\x121\n" +

--- a/catalog/azure/azurecosmosdbsqlroledefinition/v1alpha1/spec.proto
+++ b/catalog/azure/azurecosmosdbsqlroledefinition/v1alpha1/spec.proto
@@ -84,9 +84,14 @@ message AzureCosmosdbSqlRoleDefinitionSpec {
   // the account ID (references cannot append path suffixes), e.g.:
   //   assignableScopes:
   //     - value: /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.DocumentDB/databaseAccounts/{account}/dbs/app-data
+  //
+  // Where a role MAY BE ASSIGNED is not where the definition lives (that is
+  // `cosmosdb_account_id`), so on a diagram these references are access,
+  // not placement.
   repeated dev.planton.shared.foreignkey.v1.StringValueOrRef assignable_scopes = 4 [
     (buf.validate.field).repeated.min_items = 1,
     (dev.planton.shared.foreignkey.v1.default_kind) = AzureCosmosdbAccount,
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true,
     (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.cosmosdb_account_id"
   ];
 

--- a/catalog/azure/azuremssqlfailovergroup/v1alpha1/spec.pb.go
+++ b/catalog/azure/azuremssqlfailovergroup/v1alpha1/spec.pb.go
@@ -211,7 +211,9 @@ func (x *AzureMssqlFailoverGroupSpec) GetTags() map[string]string {
 type AzureMssqlFailoverGroupPartnerServer struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The partner logical server, in a different region than the primary.
-	// Defaults to referencing an AzureMssqlServer's server_id output.
+	// Defaults to referencing an AzureMssqlServer's server_id output. The
+	// group is created ON its primary and replicates TO this server, so on a
+	// diagram this reference is access, not placement.
 	ServerId      *v1.StringValueOrRef `protobuf:"bytes,1,opt,name=server_id,json=serverId,proto3" json:"server_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -331,9 +333,9 @@ const file_catalog_azure_azuremssqlfailovergroup_v1alpha1_spec_proto_rawDesc = "
 	"\tTagsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B,\n" +
-	"*_readonly_endpoint_failover_policy_enabled\"\xa0\x01\n" +
-	"$AzureMssqlFailoverGroupPartnerServer\x12x\n" +
-	"\tserver_id\x18\x01 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB'\xbaH\x03\xc8\x01\x01\x88\xd4a\xf1\x0f\x92\xd4a\x18status.outputs.server_idR\bserverId\"\x9d\x03\n" +
+	"*_readonly_endpoint_failover_policy_enabled\"\xa4\x01\n" +
+	"$AzureMssqlFailoverGroupPartnerServer\x12|\n" +
+	"\tserver_id\x18\x01 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB+\xbaH\x03\xc8\x01\x01\x88\xd4a\xf1\x0f\x92\xd4a\x18status.outputs.server_id\x98\xd4a\x01R\bserverId\"\x9d\x03\n" +
 	"&AzureMssqlFailoverGroupReadWritePolicy\x12s\n" +
 	"\x04mode\x18\x01 \x01(\x0e2W.dev.planton.azure.azuremssqlfailovergroup.v1alpha1.AzureMssqlFailoverGroupFailoverModeB\x06\xbaH\x03\xc8\x01\x01R\x04mode\x12,\n" +
 	"\rgrace_minutes\x18\x02 \x01(\x05B\a\xbaH\x04\x1a\x02(\x00R\fgraceMinutes:\xcf\x01\xbaH\xcb\x01\x1a\xc8\x01\n" +

--- a/catalog/azure/azuremssqlfailovergroup/v1alpha1/spec.proto
+++ b/catalog/azure/azuremssqlfailovergroup/v1alpha1/spec.proto
@@ -79,10 +79,13 @@ message AzureMssqlFailoverGroupSpec {
 // A partner (secondary) server in a failover group.
 message AzureMssqlFailoverGroupPartnerServer {
   // The partner logical server, in a different region than the primary.
-  // Defaults to referencing an AzureMssqlServer's server_id output.
+  // Defaults to referencing an AzureMssqlServer's server_id output. The
+  // group is created ON its primary and replicates TO this server, so on a
+  // diagram this reference is access, not placement.
   dev.planton.shared.foreignkey.v1.StringValueOrRef server_id = 1 [
     (buf.validate.field).required = true,
     (dev.planton.shared.foreignkey.v1.default_kind) = AzureMssqlServer,
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true,
     (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.server_id"
   ];
 }

--- a/shared/cloudresourcekind/testdata/containment_decisions.txt
+++ b/shared/cloudresourcekind/testdata/containment_decisions.txt
@@ -168,7 +168,6 @@ contained dev.planton.azure.azurecosmosdbsqlcontainer.v1alpha1.AzureCosmosdbSqlC
 contained dev.planton.azure.azurecosmosdbsqldatabase.v1alpha1.AzureCosmosdbSqlDatabaseSpec.cosmosdb_account_id -> AzureCosmosdbAccount
 contained dev.planton.azure.azurecosmosdbsqlroleassignment.v1alpha1.AzureCosmosdbSqlRoleAssignmentSpec.cosmosdb_account_id -> AzureCosmosdbAccount
 contained dev.planton.azure.azurecosmosdbsqlroleassignment.v1alpha1.AzureCosmosdbSqlRoleAssignmentSpec.scope -> AzureCosmosdbAccount
-contained dev.planton.azure.azurecosmosdbsqlroledefinition.v1alpha1.AzureCosmosdbSqlRoleDefinitionSpec.assignable_scopes -> AzureCosmosdbAccount
 contained dev.planton.azure.azurecosmosdbsqlroledefinition.v1alpha1.AzureCosmosdbSqlRoleDefinitionSpec.cosmosdb_account_id -> AzureCosmosdbAccount
 contained dev.planton.azure.azuredatafactory.v1alpha1.AzureDataFactorySpec.resource_group -> AzureResourceGroup
 contained dev.planton.azure.azuredatafactoryintegrationruntime.v1alpha1.AzureDataFactoryIntegrationRuntimeSsisExpressVnetIntegration.subnet_id -> AzureSubnet
@@ -263,7 +262,6 @@ contained dev.planton.azure.azuremonitormetricalert.v1alpha1.AzureMonitorMetricA
 contained dev.planton.azure.azuremonitorscheduledqueryalert.v1alpha1.AzureMonitorScheduledQueryAlertSpec.resource_group -> AzureResourceGroup
 contained dev.planton.azure.azuremssqldatabase.v1alpha1.AzureMssqlDatabaseSpec.server_id -> AzureMssqlServer
 contained dev.planton.azure.azuremssqlelasticpool.v1alpha1.AzureMssqlElasticPoolSpec.server_id -> AzureMssqlServer
-contained dev.planton.azure.azuremssqlfailovergroup.v1alpha1.AzureMssqlFailoverGroupPartnerServer.server_id -> AzureMssqlServer
 contained dev.planton.azure.azuremssqlfailovergroup.v1alpha1.AzureMssqlFailoverGroupSpec.server_id -> AzureMssqlServer
 contained dev.planton.azure.azuremssqlserver.v1alpha1.AzureMssqlServerSpec.resource_group -> AzureResourceGroup
 contained dev.planton.azure.azuremysqlflexibleserver.v1alpha1.AzureMysqlFlexibleServerSpec.delegated_subnet_id -> AzureSubnet
@@ -688,6 +686,7 @@ exempt    dev.planton.azure.azureakscluster.v1alpha1.AzureAksClusterWebAppRoutin
 exempt    dev.planton.azure.azurecontainerappenvironmentstorage.v1alpha1.AzureContainerAppEnvironmentStorageSpec.access_key -> AzureStorageAccount
 exempt    dev.planton.azure.azurecontainerappenvironmentstorage.v1alpha1.AzureContainerAppEnvironmentStorageSpec.account_name -> AzureStorageAccount
 exempt    dev.planton.azure.azurecosmosdbaccount.v1alpha1.AzureCosmosdbAccountVirtualNetworkRule.subnet_id -> AzureSubnet
+exempt    dev.planton.azure.azurecosmosdbsqlroledefinition.v1alpha1.AzureCosmosdbSqlRoleDefinitionSpec.assignable_scopes -> AzureCosmosdbAccount
 exempt    dev.planton.azure.azureeventhub.v1alpha1.AzureEventHubCaptureDestination.storage_account_id -> AzureStorageAccount
 exempt    dev.planton.azure.azureeventhubdisasterrecoveryconfig.v1alpha1.AzureEventHubDisasterRecoveryConfigSpec.partner_namespace_id -> AzureEventHubNamespace
 exempt    dev.planton.azure.azureeventhubnamespace.v1alpha1.AzureEventHubNamespaceVirtualNetworkRule.subnet_id -> AzureSubnet
@@ -714,6 +713,7 @@ exempt    dev.planton.azure.azuremonitoractiongroup.v1alpha1.AzureMonitorActionG
 exempt    dev.planton.azure.azuremonitoractivitylogalert.v1alpha1.AzureMonitorActivityLogAlertSpec.scopes -> AzureResourceGroup
 exempt    dev.planton.azure.azuremonitordiagnosticsetting.v1alpha1.AzureMonitorDiagnosticSettingSpec.eventhub_name -> AzureEventHub
 exempt    dev.planton.azure.azuremonitordiagnosticsetting.v1alpha1.AzureMonitorDiagnosticSettingSpec.storage_account_id -> AzureStorageAccount
+exempt    dev.planton.azure.azuremssqlfailovergroup.v1alpha1.AzureMssqlFailoverGroupPartnerServer.server_id -> AzureMssqlServer
 exempt    dev.planton.azure.azuremssqlserver.v1alpha1.AzureMssqlServerVirtualNetworkRule.subnet_id -> AzureSubnet
 exempt    dev.planton.azure.azuremysqlflexibleserver.v1alpha1.AzureMysqlFlexibleServerSpec.private_dns_zone_id -> AzurePrivateDnsZone
 exempt    dev.planton.azure.azurepostgresqlflexibleserver.v1alpha1.AzurePostgresqlFlexibleServerSpec.private_dns_zone_id -> AzurePrivateDnsZone


### PR DESCRIPTION
# A failover group lives on its primary, and a Cosmos DB role lives in its account

## What changed

- **A SQL failover group's partner server is containment-exempt.** `AzureMssqlFailoverGroupPartnerServer.server_id` names the secondary server the group replicates databases TO. The group is created ON its primary (`AzureMssqlFailoverGroupSpec.server_id`, which stays placement) and points at the partner, so on a diagram the partner reference is access, not placement. Before this change both references were placement, and a group naming two servers of the same kind was promoted to the room they share -- the resource group beside both servers, or nothing at all when the partner lives in another group -- instead of standing on its primary.
- **A Cosmos DB SQL role definition's assignable scopes are containment-exempt.** `AzureCosmosdbSqlRoleDefinitionSpec.assignable_scopes` lists WHERE a custom data-plane role may be granted; WHERE the definition itself lives is its `cosmosdb_account_id`, which stays placement. The same rule the subscription-level `AzureRoleDefinitionSpec.assignable_scopes` already carries.
- The containment-decision registry (`shared/cloudresourcekind/testdata/containment_decisions.txt`) moves exactly two lines from `contained` to `exempt`. Nothing else moved.

## Why

`containment_exempt` says a reference into a container is access, not placement. `AzureMssqlServer` and `AzureCosmosdbAccount` are container kinds (databases, pools, and roles are created into them), so without the exemption a failover group would be drawn beside its servers instead of on the primary it is anchored to, and a role definition whose scopes are authored into a database would be drawn inside that database instead of in the account that owns it. The partner server and the assignable scopes stay on the picture as lines, which is what they are.

## How to check

```bash
go test ./shared/cloudresourcekind/... -run TestContainmentDecisions   # green; the golden carries the two exemptions
grep -n containment_exempt catalog/azure/azuremssqlfailovergroup/v1alpha1/spec.proto catalog/azure/azurecosmosdbsqlroledefinition/v1alpha1/spec.proto
```
