### PR TITLE
fix(catalog/azure): what reaches into a storage account, an event hub, or a Service Bus topic never lives in it -- fourteen consumers and deliverers are access, not placement

### DIFF
--- a/_changelog/2026-09/2026-09-11-152500-what-reaches-into-a-storage-account-never-lives-in-it.md
+++ b/_changelog/2026-09/2026-09-11-152500-what-reaches-into-a-storage-account-never-lives-in-it.md
@@ -1,0 +1,17 @@
+# What reaches into a storage account never lives in it
+
+## What changed
+
+- **Eleven storage-account references are containment-exempt.** An AI Foundry hub and a Machine Learning workspace use a storage account as their default workspace storage (`AzureAiFoundrySpec.storage_account_id`, `AzureMachineLearningWorkspaceSpec.storage_account_id`); a Cognitive Services account reads training data from one (`AzureCognitiveAccountStorage.storage_account_id`); a Data Factory linked service is the factory's connection to a blob or Data Lake store (`AzureDataFactoryLinkedServiceAzureBlobStorage.service_endpoint`, `AzureDataFactoryLinkedServiceDataLakeStorageGen2.url`) and a blob-event trigger listens to one (`AzureDataFactoryTriggerBlobEvent.storage_account_id`); an Event Grid subscription dead-letters into one and delivers into a queue in one (`AzureEventgridEventSubscriptionDeadLetter.storage_account_id`, `AzureEventgridEventSubscriptionStorageQueueDestination.storage_account_id`); a data collection rule delivers collected data into one (`AzureMonitorDataCollectionRuleStorageBlobDestination.storage_account_id`, `AzureMonitorDataCollectionRuleStorageTableDirect.storage_account_id`); and a Recovery Services backup container registers one with a vault (`AzureBackupContainerStorageAccountSpec.storage_account_id`). Every one of those resources READS, WRITES, LISTENS TO, or REGISTERS the account and lives somewhere else -- in its own resource group, its factory, its topic, or its vault -- so on a diagram each reference is access, not placement. Each field's comment now says so.
+- The containment-decision registry (`shared/cloudresourcekind/testdata/containment_decisions.txt`) moves exactly eleven lines from `contained` to `exempt`. Nothing else moved.
+
+## Why
+
+`containment_exempt` says a reference into a container is access, not placement. The storage account is a container kind (its blob containers, file shares, queues, tables, Data Lake filesystems, encryption scopes, and local users are created into it), so without the exemption a workspace, a linked service, an event subscription, or a monitoring rule that references the account it writes to was drawn INSIDE that account -- a consumer drawn as a resident of what it merely uses. The Network Watcher flow log, the diagnostic setting, the Event Hub capture destination, the Function App's storage, and the Container App environment's storage registration already carried the same exemption for the same reason; these eleven now agree with them. The references stay on the picture as lines, which is what they are.
+
+## How to check
+
+```bash
+go test ./shared/cloudresourcekind/... -run TestContainmentDecisions   # green; the golden carries the eleven exemptions
+grep -rn containment_exempt catalog/azure/azureaifoundry catalog/azure/azurecognitiveaccount catalog/azure/azuredatafactorylinkedservice catalog/azure/azuredatafactorytrigger catalog/azure/azureeventgrideventsubscription catalog/azure/azuremachinelearningworkspace catalog/azure/azuremonitordatacollectionrule catalog/azure/azurebackupcontainerstorageaccount --include=spec.proto
+```

--- a/_changelog/2026-09/2026-09-11-152500-what-reaches-into-a-storage-account-never-lives-in-it.md
+++ b/_changelog/2026-09/2026-09-11-152500-what-reaches-into-a-storage-account-never-lives-in-it.md
@@ -1,9 +1,10 @@
-# What reaches into a storage account never lives in it
+# What reaches into a storage account, an event hub, or a Service Bus topic never lives in it
 
 ## What changed
 
+- **Three delivery destinations are containment-exempt.** An Event Grid subscription delivers events into an event hub or a Service Bus topic (`AzureEventgridEventSubscriptionDestination.eventhub_id`, `.service_bus_topic_id`), and a data collection rule delivers collected data into an event hub (`AzureMonitorDataCollectionRuleEventHubDestination.event_hub_id`). Each of those resources lives somewhere else -- the subscription with the Event Grid topic it subscribes to, the rule in its own resource group -- and the hub and the topic are container kinds (consumer groups and subscriptions are created into them), so without the exemption a subscription or a rule was drawn INSIDE the stream it delivers into. Same file, same rule as the storage-account lines below; the Event Grid subscription's and the rule's storage destinations already carried it.
 - **Eleven storage-account references are containment-exempt.** An AI Foundry hub and a Machine Learning workspace use a storage account as their default workspace storage (`AzureAiFoundrySpec.storage_account_id`, `AzureMachineLearningWorkspaceSpec.storage_account_id`); a Cognitive Services account reads training data from one (`AzureCognitiveAccountStorage.storage_account_id`); a Data Factory linked service is the factory's connection to a blob or Data Lake store (`AzureDataFactoryLinkedServiceAzureBlobStorage.service_endpoint`, `AzureDataFactoryLinkedServiceDataLakeStorageGen2.url`) and a blob-event trigger listens to one (`AzureDataFactoryTriggerBlobEvent.storage_account_id`); an Event Grid subscription dead-letters into one and delivers into a queue in one (`AzureEventgridEventSubscriptionDeadLetter.storage_account_id`, `AzureEventgridEventSubscriptionStorageQueueDestination.storage_account_id`); a data collection rule delivers collected data into one (`AzureMonitorDataCollectionRuleStorageBlobDestination.storage_account_id`, `AzureMonitorDataCollectionRuleStorageTableDirect.storage_account_id`); and a Recovery Services backup container registers one with a vault (`AzureBackupContainerStorageAccountSpec.storage_account_id`). Every one of those resources READS, WRITES, LISTENS TO, or REGISTERS the account and lives somewhere else -- in its own resource group, its factory, its topic, or its vault -- so on a diagram each reference is access, not placement. Each field's comment now says so.
-- The containment-decision registry (`shared/cloudresourcekind/testdata/containment_decisions.txt`) moves exactly eleven lines from `contained` to `exempt`. Nothing else moved.
+- The containment-decision registry (`shared/cloudresourcekind/testdata/containment_decisions.txt`) moves exactly fourteen lines from `contained` to `exempt`. Nothing else moved.
 
 ## Why
 
@@ -12,6 +13,6 @@
 ## How to check
 
 ```bash
-go test ./shared/cloudresourcekind/... -run TestContainmentDecisions   # green; the golden carries the eleven exemptions
+go test ./shared/cloudresourcekind/... -run TestContainmentDecisions   # green; the golden carries the fourteen exemptions
 grep -rn containment_exempt catalog/azure/azureaifoundry catalog/azure/azurecognitiveaccount catalog/azure/azuredatafactorylinkedservice catalog/azure/azuredatafactorytrigger catalog/azure/azureeventgrideventsubscription catalog/azure/azuremachinelearningworkspace catalog/azure/azuremonitordatacollectionrule catalog/azure/azurebackupcontainerstorageaccount --include=spec.proto
 ```

--- a/catalog/azure/azureaifoundry/v1alpha1/spec.pb.go
+++ b/catalog/azure/azureaifoundry/v1alpha1/spec.pb.go
@@ -189,6 +189,11 @@ type AzureAiFoundrySpec struct {
 	// by ARM ID. Use a general-purpose account WITHOUT hierarchical
 	// namespace -- the hub is an ML workspace at ARM, which rejects
 	// Data Lake Gen2 accounts as default storage. Fixed at creation.
+	//
+	// The hub READS and WRITES this account as its default workspace storage
+	// and lives in its own resource group, so on a diagram the reference is
+	// access, not placement -- the same rule its key_vault_id already
+	// carries.
 	StorageAccountId *v1.StringValueOrRef `protobuf:"bytes,5,opt,name=storage_account_id,json=storageAccountId,proto3" json:"storage_account_id,omitempty"`
 	// The hub's managed identity. REQUIRED -- the hub accesses its
 	// companion services (key vault, storage, insights, registry)
@@ -575,15 +580,15 @@ var File_catalog_azure_azureaifoundry_v1alpha1_spec_proto protoreflect.FileDescr
 
 const file_catalog_azure_azureaifoundry_v1alpha1_spec_proto_rawDesc = "" +
 	"\n" +
-	"0catalog/azure/azureaifoundry/v1alpha1/spec.proto\x12)dev.planton.azure.azureaifoundry.v1alpha1\x1a\x1bbuf/validate/validate.proto\x1a&shared/foreignkey/v1/foreign_key.proto\x1a\x1cshared/options/options.proto\"\xc4\r\n" +
+	"0catalog/azure/azureaifoundry/v1alpha1/spec.proto\x12)dev.planton.azure.azureaifoundry.v1alpha1\x1a\x1bbuf/validate/validate.proto\x1a&shared/foreignkey/v1/foreign_key.proto\x1a\x1cshared/options/options.proto\"\xc8\r\n" +
 	"\x12AzureAiFoundrySpec\x12\"\n" +
 	"\x06region\x18\x01 \x01(\tB\n" +
 	"\xbaH\a\xc8\x01\x01r\x02\x10\x01R\x06region\x12\x8c\x01\n" +
 	"\x0eresource_group\x18\x02 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB1\xbaH\x03\xc8\x01\x01\x88\xd4a\xd0\x0f\x92\xd4a\"status.outputs.resource_group_nameR\rresourceGroup\x12>\n" +
 	"\x04name\x18\x03 \x01(\tB*\xbaH'\xc8\x01\x01r\"2 ^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$R\x04name\x12\x80\x01\n" +
 	"\fkey_vault_id\x18\x04 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB*\xbaH\x03\xc8\x01\x01\x88\xd4a\xd5\x0f\x92\xd4a\x1bstatus.outputs.key_vault_idR\n" +
-	"keyVaultId\x12\x92\x01\n" +
-	"\x12storage_account_id\x18\x05 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB0\xbaH\x03\xc8\x01\x01\x88\xd4a\xd9\x0f\x92\xd4a!status.outputs.storage_account_idR\x10storageAccountId\x12e\n" +
+	"keyVaultId\x12\x96\x01\n" +
+	"\x12storage_account_id\x18\x05 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB4\xbaH\x03\xc8\x01\x01\x88\xd4a\xd9\x0f\x92\xd4a!status.outputs.storage_account_id\x98\xd4a\x01R\x10storageAccountId\x12e\n" +
 	"\bidentity\x18\x06 \x01(\v2A.dev.planton.azure.azureaifoundry.v1alpha1.AzureAiFoundryIdentityB\x06\xbaH\x03\xc8\x01\x01R\bidentity\x12\x9b\x01\n" +
 	"\x17application_insights_id\x18\a \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB/\x88\xd4a\x83\x10\x92\xd4a&status.outputs.application_insights_idR\x15applicationInsightsId\x12\x95\x01\n" +
 	"\x15container_registry_id\x18\b \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB-\x88\xd4a\xd3\x0f\x92\xd4a$status.outputs.container_registry_idR\x13containerRegistryId\x12\x9c\x01\n" +

--- a/catalog/azure/azureaifoundry/v1alpha1/spec.proto
+++ b/catalog/azure/azureaifoundry/v1alpha1/spec.proto
@@ -69,9 +69,15 @@ message AzureAiFoundrySpec {
   // by ARM ID. Use a general-purpose account WITHOUT hierarchical
   // namespace -- the hub is an ML workspace at ARM, which rejects
   // Data Lake Gen2 accounts as default storage. Fixed at creation.
+  //
+  // The hub READS and WRITES this account as its default workspace storage
+  // and lives in its own resource group, so on a diagram the reference is
+  // access, not placement -- the same rule its key_vault_id already
+  // carries.
   dev.planton.shared.foreignkey.v1.StringValueOrRef storage_account_id = 5 [
     (buf.validate.field).required = true,
     (dev.planton.shared.foreignkey.v1.default_kind) = AzureStorageAccount,
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true,
     (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.storage_account_id"
   ];
 

--- a/catalog/azure/azurebackupcontainerstorageaccount/v1alpha1/spec.pb.go
+++ b/catalog/azure/azurebackupcontainerstorageaccount/v1alpha1/spec.pb.go
@@ -52,6 +52,10 @@ type AzureBackupContainerStorageAccountSpec struct {
 	RecoveryVaultName *v1.StringValueOrRef `protobuf:"bytes,2,opt,name=recovery_vault_name,json=recoveryVaultName,proto3" json:"recovery_vault_name,omitempty"`
 	// The storage account to register, by ARM ID. The account must live
 	// in the vault's region (Azure Files backup is regional).
+	//
+	// The registration REGISTERS this account with the vault and is an ARM
+	// child of the vault, never a thing inside the account, so on a diagram
+	// the reference is access, not placement.
 	StorageAccountId *v1.StringValueOrRef `protobuf:"bytes,3,opt,name=storage_account_id,json=storageAccountId,proto3" json:"storage_account_id,omitempty"`
 	unknownFields    protoimpl.UnknownFields
 	sizeCache        protoimpl.SizeCache
@@ -112,11 +116,11 @@ var File_catalog_azure_azurebackupcontainerstorageaccount_v1alpha1_spec_proto pr
 
 const file_catalog_azure_azurebackupcontainerstorageaccount_v1alpha1_spec_proto_rawDesc = "" +
 	"\n" +
-	"Dcatalog/azure/azurebackupcontainerstorageaccount/v1alpha1/spec.proto\x12=dev.planton.azure.azurebackupcontainerstorageaccount.v1alpha1\x1a\x1bbuf/validate/validate.proto\x1a&shared/foreignkey/v1/foreign_key.proto\"\xed\x03\n" +
+	"Dcatalog/azure/azurebackupcontainerstorageaccount/v1alpha1/spec.proto\x12=dev.planton.azure.azurebackupcontainerstorageaccount.v1alpha1\x1a\x1bbuf/validate/validate.proto\x1a&shared/foreignkey/v1/foreign_key.proto\"\xf1\x03\n" +
 	"&AzureBackupContainerStorageAccountSpec\x12\x8c\x01\n" +
 	"\x0eresource_group\x18\x01 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB1\xbaH\x03\xc8\x01\x01\x88\xd4a\xd0\x0f\x92\xd4a\"status.outputs.resource_group_nameR\rresourceGroup\x12\x9e\x01\n" +
-	"\x13recovery_vault_name\x18\x02 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB:\xbaH\x03\xc8\x01\x01\x88\xd4a\xff\x10\x92\xd4a+status.outputs.recovery_services_vault_nameR\x11recoveryVaultName\x12\x92\x01\n" +
-	"\x12storage_account_id\x18\x03 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB0\xbaH\x03\xc8\x01\x01\x88\xd4a\xd9\x0f\x92\xd4a!status.outputs.storage_account_idR\x10storageAccountIdB\xeb\x03\n" +
+	"\x13recovery_vault_name\x18\x02 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB:\xbaH\x03\xc8\x01\x01\x88\xd4a\xff\x10\x92\xd4a+status.outputs.recovery_services_vault_nameR\x11recoveryVaultName\x12\x96\x01\n" +
+	"\x12storage_account_id\x18\x03 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB4\xbaH\x03\xc8\x01\x01\x88\xd4a\xd9\x0f\x92\xd4a!status.outputs.storage_account_id\x98\xd4a\x01R\x10storageAccountIdB\xeb\x03\n" +
 	"Acom.dev.planton.azure.azurebackupcontainerstorageaccount.v1alpha1B\tSpecProtoP\x01Z\x81\x01github.com/plantonhq/planton/catalog/azure/azurebackupcontainerstorageaccount/v1alpha1;azurebackupcontainerstorageaccountv1alpha1\xa2\x02\x04DPAA\xaa\x02=Dev.Planton.Azure.Azurebackupcontainerstorageaccount.V1alpha1\xca\x02=Dev\\Planton\\Azure\\Azurebackupcontainerstorageaccount\\V1alpha1\xe2\x02IDev\\Planton\\Azure\\Azurebackupcontainerstorageaccount\\V1alpha1\\GPBMetadata\xea\x02ADev::Planton::Azure::Azurebackupcontainerstorageaccount::V1alpha1b\x06proto3"
 
 var (

--- a/catalog/azure/azurebackupcontainerstorageaccount/v1alpha1/spec.proto
+++ b/catalog/azure/azurebackupcontainerstorageaccount/v1alpha1/spec.proto
@@ -43,9 +43,14 @@ message AzureBackupContainerStorageAccountSpec {
 
   // The storage account to register, by ARM ID. The account must live
   // in the vault's region (Azure Files backup is regional).
+  //
+  // The registration REGISTERS this account with the vault and is an ARM
+  // child of the vault, never a thing inside the account, so on a diagram
+  // the reference is access, not placement.
   dev.planton.shared.foreignkey.v1.StringValueOrRef storage_account_id = 3 [
     (buf.validate.field).required = true,
     (dev.planton.shared.foreignkey.v1.default_kind) = AzureStorageAccount,
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true,
     (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.storage_account_id"
   ];
 }

--- a/catalog/azure/azurecognitiveaccount/v1alpha1/spec.pb.go
+++ b/catalog/azure/azurecognitiveaccount/v1alpha1/spec.pb.go
@@ -951,6 +951,10 @@ func (x *AzureCognitiveAccountNetworkInjection) GetSubnetId() *v1.StringValueOrR
 type AzureCognitiveAccountStorage struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The storage account's ARM ID.
+	//
+	// The account reads training data and writes results here and lives in
+	// its own resource group, so on a diagram the reference is access, not
+	// placement.
 	StorageAccountId *v1.StringValueOrRef `protobuf:"bytes,1,opt,name=storage_account_id,json=storageAccountId,proto3" json:"storage_account_id,omitempty"`
 	// The client ID of the USER-ASSIGNED identity that accesses the
 	// storage account. Leave unset to use the system-assigned identity.
@@ -1332,9 +1336,9 @@ const file_catalog_azure_azurecognitiveaccount_v1alpha1_spec_proto_rawDesc = "" 
 	"$ignore_missing_vnet_service_endpoint\x18\x02 \x01(\bR ignoreMissingVnetServiceEndpoint\"\xce\x01\n" +
 	"%AzureCognitiveAccountNetworkInjection\x12+\n" +
 	"\bscenario\x18\x01 \x01(\tB\x0f\xbaH\f\xc8\x01\x01r\aR\x05agentR\bscenario\x12x\n" +
-	"\tsubnet_id\x18\x02 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB'\xbaH\x03\xc8\x01\x01\x88\xd4a\xdb\x0f\x92\xd4a\x18status.outputs.subnet_idR\bsubnetId\"\xee\x01\n" +
-	"\x1cAzureCognitiveAccountStorage\x12\x92\x01\n" +
-	"\x12storage_account_id\x18\x01 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB0\xbaH\x03\xc8\x01\x01\x88\xd4a\xd9\x0f\x92\xd4a!status.outputs.storage_account_idR\x10storageAccountId\x129\n" +
+	"\tsubnet_id\x18\x02 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB'\xbaH\x03\xc8\x01\x01\x88\xd4a\xdb\x0f\x92\xd4a\x18status.outputs.subnet_idR\bsubnetId\"\xf2\x01\n" +
+	"\x1cAzureCognitiveAccountStorage\x12\x96\x01\n" +
+	"\x12storage_account_id\x18\x01 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB4\xbaH\x03\xc8\x01\x01\x88\xd4a\xd9\x0f\x92\xd4a!status.outputs.storage_account_id\x98\xd4a\x01R\x10storageAccountId\x129\n" +
 	"\x12identity_client_id\x18\x02 \x01(\tB\v\xbaH\b\xd8\x01\x01r\x03\xb0\x01\x01R\x10identityClientId\"\xa6\x02\n" +
 	"!AzureCognitiveAccountRaiBlocklist\x123\n" +
 	"\x04name\x18\x01 \x01(\tB\x1f\xbaH\x1c\xc8\x01\x01r\x172\x15^[a-zA-Z0-9_-]{2,64}$R\x04name\x12 \n" +

--- a/catalog/azure/azurecognitiveaccount/v1alpha1/spec.proto
+++ b/catalog/azure/azurecognitiveaccount/v1alpha1/spec.proto
@@ -478,9 +478,14 @@ message AzureCognitiveAccountNetworkInjection {
 // One user-owned storage attachment.
 message AzureCognitiveAccountStorage {
   // The storage account's ARM ID.
+  //
+  // The account reads training data and writes results here and lives in
+  // its own resource group, so on a diagram the reference is access, not
+  // placement.
   dev.planton.shared.foreignkey.v1.StringValueOrRef storage_account_id = 1 [
     (buf.validate.field).required = true,
     (dev.planton.shared.foreignkey.v1.default_kind) = AzureStorageAccount,
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true,
     (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.storage_account_id"
   ];
 

--- a/catalog/azure/azuredatafactorylinkedservice/v1alpha1/spec.pb.go
+++ b/catalog/azure/azuredatafactorylinkedservice/v1alpha1/spec.pb.go
@@ -534,6 +534,11 @@ type AzureDataFactoryLinkedServiceAzureBlobStorage struct {
 	// no-secret form: authentication comes from managed identity
 	// (use_managed_identity) or a service principal. Azure stores it as
 	// a secure string (mirrored: marked sensitive).
+	//
+	// A linked service is the factory's connection definition for a store it
+	// reads from and writes to; it never lives inside the account, so on a
+	// diagram the reference is access, not placement -- the same rule its Key
+	// Vault references already carry.
 	ServiceEndpoint *v1.StringValueOrRef `protobuf:"bytes,4,opt,name=service_endpoint,json=serviceEndpoint,proto3" json:"service_endpoint,omitempty"`
 	// Holds the SAS token in Key Vault (used with sas_uri: the URI
 	// carries the address, the vault carries the token).
@@ -1623,6 +1628,10 @@ type AzureDataFactoryLinkedServiceDataLakeStorageGen2 struct {
 	// The Data Lake endpoint URL (https://account.dfs.core.windows.net)
 	// -- defaults to referencing an AzureStorageAccount's
 	// primary_dfs_endpoint output.
+	//
+	// A linked service is the factory's connection definition for a store it
+	// reads from and writes to; it never lives inside the account, so on a
+	// diagram the reference is access, not placement.
 	Url *v1.StringValueOrRef `protobuf:"bytes,1,opt,name=url,proto3" json:"url,omitempty"`
 	// Authenticate as the factory's managed identity -- the no-secret
 	// mode. Unspecified applies false. One of the three authentication
@@ -2689,12 +2698,12 @@ const file_catalog_azure_azuredatafactorylinkedservice_v1alpha1_spec_proto_rawDe
 	"&AzureDataFactoryLinkedServiceBasicAuth\x12\"\n" +
 	"\busername\x18\x01 \x01(\tB\x06\xbaH\x03\xc8\x01\x01R\busername\x12&\n" +
 	"\bpassword\x18\x02 \x01(\tB\n" +
-	"\xbaH\x03\xc8\x01\x01\xa0\xa6\x1d\x01R\bpassword\"\xae\x0f\n" +
+	"\xbaH\x03\xc8\x01\x01\xa0\xa6\x1d\x01R\bpassword\"\xb2\x0f\n" +
 	"-AzureDataFactoryLinkedServiceAzureBlobStorage\x121\n" +
 	"\x11connection_string\x18\x01 \x01(\tB\x04\xa0\xa6\x1d\x01R\x10connectionString\x12\xf9\x01\n" +
 	"\x1aconnection_string_insecure\x18\x02 \x01(\tB\xba\x01\xaa\xa6\x1d\xb5\x01The deliberately-PLAIN-TEXT connection form (the provider's own contrast to connection_string): its contract is carrying NO secret material, and Azure stores and returns it readableR\x18connectionStringInsecure\x12\x1d\n" +
-	"\asas_uri\x18\x03 \x01(\tB\x04\xa0\xa6\x1d\x01R\x06sasUri\x12\x90\x01\n" +
-	"\x10service_endpoint\x18\x04 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB1\xa0\xa6\x1d\x01\x88\xd4a\xd9\x0f\x92\xd4a$status.outputs.primary_blob_endpointR\x0fserviceEndpoint\x12\xab\x01\n" +
+	"\asas_uri\x18\x03 \x01(\tB\x04\xa0\xa6\x1d\x01R\x06sasUri\x12\x94\x01\n" +
+	"\x10service_endpoint\x18\x04 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB5\xa0\xa6\x1d\x01\x88\xd4a\xd9\x0f\x92\xd4a$status.outputs.primary_blob_endpoint\x98\xd4a\x01R\x0fserviceEndpoint\x12\xab\x01\n" +
 	"\x1esas_token_linked_key_vault_key\x18\x05 \x01(\v2h.dev.planton.azure.azuredatafactorylinkedservice.v1alpha1.AzureDataFactoryLinkedServiceKeyVaultSecretRefR\x19sasTokenLinkedKeyVaultKey\x12\xbb\x01\n" +
 	"&service_principal_linked_key_vault_key\x18\x06 \x01(\v2h.dev.planton.azure.azuredatafactorylinkedservice.v1alpha1.AzureDataFactoryLinkedServiceKeyVaultSecretRefR!servicePrincipalLinkedKeyVaultKey\x12]\n" +
 	"\fstorage_kind\x18\a \x01(\tB:\xbaH7r5R\x00R\aStorageR\tStorageV2R\vBlobStorageR\x10BlockBlobStorageR\vstorageKind\x12@\n" +
@@ -2804,9 +2813,9 @@ const file_catalog_azure_azuredatafactorylinkedservice_v1alpha1_spec_proto_rawDe
 	"\x1eintegration_runtime_parameters\x18\x03 \x03(\v2\x7f.dev.planton.azure.azuredatafactorylinkedservice.v1alpha1.AzureDataFactoryLinkedServiceCustom.IntegrationRuntimeParametersEntryR\x1cintegrationRuntimeParameters\x1aO\n" +
 	"!IntegrationRuntimeParametersEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xfb\t\n" +
-	"0AzureDataFactoryLinkedServiceDataLakeStorageGen2\x12x\n" +
-	"\x03url\x18\x01 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB2\xbaH\x03\xc8\x01\x01\x88\xd4a\xd9\x0f\x92\xd4a#status.outputs.primary_dfs_endpointR\x03url\x12@\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xff\t\n" +
+	"0AzureDataFactoryLinkedServiceDataLakeStorageGen2\x12|\n" +
+	"\x03url\x18\x01 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB6\xbaH\x03\xc8\x01\x01\x88\xd4a\xd9\x0f\x92\xd4a#status.outputs.primary_dfs_endpoint\x98\xd4a\x01R\x03url\x12@\n" +
 	"\x14use_managed_identity\x18\x02 \x01(\bB\t\x8a\xa6\x1d\x05falseH\x00R\x12useManagedIdentity\x88\x01\x01\x124\n" +
 	"\x13storage_account_key\x18\x03 \x01(\tB\x04\xa0\xa6\x1d\x01R\x11storageAccountKey\x12\xfa\x01\n" +
 	"\x14service_principal_id\x18\x04 \x01(\tB\xc7\x01\xbaH\xc3\x01\xba\x01\xbf\x01\n" +

--- a/catalog/azure/azuredatafactorylinkedservice/v1alpha1/spec.proto
+++ b/catalog/azure/azuredatafactorylinkedservice/v1alpha1/spec.proto
@@ -242,9 +242,15 @@ message AzureDataFactoryLinkedServiceAzureBlobStorage {
   // no-secret form: authentication comes from managed identity
   // (use_managed_identity) or a service principal. Azure stores it as
   // a secure string (mirrored: marked sensitive).
+  //
+  // A linked service is the factory's connection definition for a store it
+  // reads from and writes to; it never lives inside the account, so on a
+  // diagram the reference is access, not placement -- the same rule its Key
+  // Vault references already carry.
   dev.planton.shared.foreignkey.v1.StringValueOrRef service_endpoint = 4 [
     (dev.planton.shared.options.sensitive) = true,
     (dev.planton.shared.foreignkey.v1.default_kind) = AzureStorageAccount,
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true,
     (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.primary_blob_endpoint"
   ];
 
@@ -681,9 +687,14 @@ message AzureDataFactoryLinkedServiceDataLakeStorageGen2 {
   // The Data Lake endpoint URL (https://account.dfs.core.windows.net)
   // -- defaults to referencing an AzureStorageAccount's
   // primary_dfs_endpoint output.
+  //
+  // A linked service is the factory's connection definition for a store it
+  // reads from and writes to; it never lives inside the account, so on a
+  // diagram the reference is access, not placement.
   dev.planton.shared.foreignkey.v1.StringValueOrRef url = 1 [
     (buf.validate.field).required = true,
     (dev.planton.shared.foreignkey.v1.default_kind) = AzureStorageAccount,
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true,
     (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.primary_dfs_endpoint"
   ];
 

--- a/catalog/azure/azuredatafactorytrigger/v1alpha1/spec.pb.go
+++ b/catalog/azure/azuredatafactorytrigger/v1alpha1/spec.pb.go
@@ -741,6 +741,9 @@ type AzureDataFactoryTriggerBlobEvent struct {
 	// ID -- defaults to referencing an AzureStorageAccount's
 	// storage_account_id output. FIXED AT CREATION -- changing it
 	// replaces the trigger.
+	//
+	// The trigger LISTENS to this account's blob events and belongs to its
+	// factory, so on a diagram the reference is access, not placement.
 	StorageAccountId *v1.StringValueOrRef `protobuf:"bytes,1,opt,name=storage_account_id,json=storageAccountId,proto3" json:"storage_account_id,omitempty"`
 	// Which blob events fire the trigger (at least one).
 	Events []string `protobuf:"bytes,2,rep,name=events,proto3" json:"events,omitempty"`
@@ -1090,9 +1093,9 @@ const file_catalog_azure_azuredatafactorytrigger_v1alpha1_spec_proto_rawDesc = "
 	"\x06offset\x18\x02 \x01(\tB\xcb\x01\xbaH\xc7\x01\xba\x01\xc3\x01\n" +
 	"/data_factory_trigger_dependency_offset_timespan\x124offset must be a TimeSpan like 24:00:00 or -24:00:00\x1aZthis == '' || this.matches('^-?((\\\\d+)\\\\.)?(\\\\d\\\\d):(60|([0-5][0-9])):(60|([0-5][0-9]))$')R\x06offset\x12\xcf\x01\n" +
 	"\x04size\x18\x03 \x01(\tB\xba\x01\xbaH\xb6\x01\xba\x01\xb2\x01\n" +
-	"-data_factory_trigger_dependency_size_timespan\x12%size must be a TimeSpan like 06:00:00\x1aZthis == '' || this.matches('^-?((\\\\d+)\\\\.)?(\\\\d\\\\d):(60|([0-5][0-9])):(60|([0-5][0-9]))$')R\x04size\"\x82\b\n" +
-	" AzureDataFactoryTriggerBlobEvent\x12\x92\x01\n" +
-	"\x12storage_account_id\x18\x01 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB0\xbaH\x03\xc8\x01\x01\x88\xd4a\xd9\x0f\x92\xd4a!status.outputs.storage_account_idR\x10storageAccountId\x12b\n" +
+	"-data_factory_trigger_dependency_size_timespan\x12%size must be a TimeSpan like 06:00:00\x1aZthis == '' || this.matches('^-?((\\\\d+)\\\\.)?(\\\\d\\\\d):(60|([0-5][0-9])):(60|([0-5][0-9]))$')R\x04size\"\x86\b\n" +
+	" AzureDataFactoryTriggerBlobEvent\x12\x96\x01\n" +
+	"\x12storage_account_id\x18\x01 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB4\xbaH\x03\xc8\x01\x01\x88\xd4a\xd9\x0f\x92\xd4a!status.outputs.storage_account_id\x98\xd4a\x01R\x10storageAccountId\x12b\n" +
 	"\x06events\x18\x02 \x03(\tBJ\xbaHG\x92\x01D\b\x01\"@r>R\x1dMicrosoft.Storage.BlobCreatedR\x1dMicrosoft.Storage.BlobDeletedR\x06events\x121\n" +
 	"\x15blob_path_begins_with\x18\x03 \x01(\tR\x12blobPathBeginsWith\x12-\n" +
 	"\x13blob_path_ends_with\x18\x04 \x01(\tR\x10blobPathEndsWith\x12<\n" +

--- a/catalog/azure/azuredatafactorytrigger/v1alpha1/spec.proto
+++ b/catalog/azure/azuredatafactorytrigger/v1alpha1/spec.proto
@@ -382,9 +382,13 @@ message AzureDataFactoryTriggerBlobEvent {
   // ID -- defaults to referencing an AzureStorageAccount's
   // storage_account_id output. FIXED AT CREATION -- changing it
   // replaces the trigger.
+  //
+  // The trigger LISTENS to this account's blob events and belongs to its
+  // factory, so on a diagram the reference is access, not placement.
   dev.planton.shared.foreignkey.v1.StringValueOrRef storage_account_id = 1 [
     (buf.validate.field).required = true,
     (dev.planton.shared.foreignkey.v1.default_kind) = AzureStorageAccount,
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true,
     (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.storage_account_id"
   ];
 

--- a/catalog/azure/azureeventgrideventsubscription/v1alpha1/spec.pb.go
+++ b/catalog/azure/azureeventgrideventsubscription/v1alpha1/spec.pb.go
@@ -530,6 +530,10 @@ type AzureEventgridEventSubscriptionStorageQueueDestination struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The storage account holding the queue, by ARM ID -- defaults to
 	// referencing an AzureStorageAccount's storage_account_id output.
+	//
+	// Events are DELIVERED into a queue in this account; the subscription
+	// belongs to the topic it subscribes to, so on a diagram the reference is
+	// access, not placement.
 	StorageAccountId *v1.StringValueOrRef `protobuf:"bytes,1,opt,name=storage_account_id,json=storageAccountId,proto3" json:"storage_account_id,omitempty"`
 	// The queue's name within that account (the queue must exist --
 	// AzureStorageQueue manages one).
@@ -839,6 +843,10 @@ type AzureEventgridEventSubscriptionDeadLetter struct {
 	// The storage account holding the dead-letter container, by ARM ID
 	// -- defaults to referencing an AzureStorageAccount's
 	// storage_account_id output.
+	//
+	// Dead-lettered events are WRITTEN into this account; the subscription
+	// belongs to the topic it subscribes to, so on a diagram the reference is
+	// access, not placement.
 	StorageAccountId *v1.StringValueOrRef `protobuf:"bytes,1,opt,name=storage_account_id,json=storageAccountId,proto3" json:"storage_account_id,omitempty"`
 	// The blob container dead-lettered events are written into (the
 	// container must exist -- AzureStorageContainer manages one).
@@ -1665,9 +1673,9 @@ const file_catalog_azure_azureeventgrideventsubscription_v1alpha1_spec_proto_raw
 	"\x14max_events_per_batch\x18\x02 \x01(\x05B\a\xbaH\x04\x1a\x02(\x01H\x00R\x11maxEventsPerBatch\x88\x01\x01\x12V\n" +
 	"!preferred_batch_size_in_kilobytes\x18\x03 \x01(\x05B\a\xbaH\x04\x1a\x02(\x01H\x01R\x1dpreferredBatchSizeInKilobytes\x88\x01\x01B\x17\n" +
 	"\x15_max_events_per_batchB$\n" +
-	"\"_preferred_batch_size_in_kilobytes\"\xf7\x02\n" +
-	"6AzureEventgridEventSubscriptionStorageQueueDestination\x12\x92\x01\n" +
-	"\x12storage_account_id\x18\x01 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB0\xbaH\x03\xc8\x01\x01\x88\xd4a\xd9\x0f\x92\xd4a!status.outputs.storage_account_idR\x10storageAccountId\x12)\n" +
+	"\"_preferred_batch_size_in_kilobytes\"\xfb\x02\n" +
+	"6AzureEventgridEventSubscriptionStorageQueueDestination\x12\x96\x01\n" +
+	"\x12storage_account_id\x18\x01 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB4\xbaH\x03\xc8\x01\x01\x88\xd4a\xd9\x0f\x92\xd4a!status.outputs.storage_account_id\x98\xd4a\x01R\x10storageAccountId\x12)\n" +
 	"\n" +
 	"queue_name\x18\x02 \x01(\tB\n" +
 	"\xbaH\a\xc8\x01\x01r\x02\x10\x01R\tqueueName\x12S\n" +
@@ -1696,9 +1704,9 @@ const file_catalog_azure_azureeventgrideventsubscription_v1alpha1_spec_proto_raw
 	"\x05value\x18\x03 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB\x04\xa0\xa6\x1d\x01R\x05value\x12!\n" +
 	"\fsource_field\x18\x04 \x01(\tR\vsourceField\x12\x16\n" +
 	"\x06secret\x18\x05 \x01(\bR\x06secret:\xb8\x02\xbaH\xb4\x02\x1a\xb1\x02\n" +
-	",event_subscription_delivery_property_pairing\x12xStatic entries require value (and may set secret); Dynamic entries require source_field and must not set value or secret\x1a\x86\x01(this.type == 'Static') ? (has(this.value) && this.source_field == '') : (this.source_field != '' && !has(this.value) && !this.secret)\"\x8b\x02\n" +
-	")AzureEventgridEventSubscriptionDeadLetter\x12\x92\x01\n" +
-	"\x12storage_account_id\x18\x01 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB0\xbaH\x03\xc8\x01\x01\x88\xd4a\xd9\x0f\x92\xd4a!status.outputs.storage_account_idR\x10storageAccountId\x12I\n" +
+	",event_subscription_delivery_property_pairing\x12xStatic entries require value (and may set secret); Dynamic entries require source_field and must not set value or secret\x1a\x86\x01(this.type == 'Static') ? (has(this.value) && this.source_field == '') : (this.source_field != '' && !has(this.value) && !this.secret)\"\x8f\x02\n" +
+	")AzureEventgridEventSubscriptionDeadLetter\x12\x96\x01\n" +
+	"\x12storage_account_id\x18\x01 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB4\xbaH\x03\xc8\x01\x01\x88\xd4a\xd9\x0f\x92\xd4a!status.outputs.storage_account_id\x98\xd4a\x01R\x10storageAccountId\x12I\n" +
 	"\x1bstorage_blob_container_name\x18\x02 \x01(\tB\n" +
 	"\xbaH\a\xc8\x01\x01r\x02\x10\x01R\x18storageBlobContainerName\"\xab\x03\n" +
 	",AzureEventgridEventSubscriptionSubjectFilter\x12.\n" +

--- a/catalog/azure/azureeventgrideventsubscription/v1alpha1/spec.pb.go
+++ b/catalog/azure/azureeventgrideventsubscription/v1alpha1/spec.pb.go
@@ -352,6 +352,10 @@ type AzureEventgridEventSubscriptionDestination struct {
 	// Deliver to an Event Hub, by ARM ID -- defaults to referencing an
 	// AzureEventHub's event_hub_id output. Set exactly one arm on this
 	// block.
+	//
+	// Events are DELIVERED into the hub; the subscription belongs to the
+	// topic it subscribes to, so on a diagram the reference is access, not
+	// placement.
 	EventhubId *v1.StringValueOrRef `protobuf:"bytes,2,opt,name=eventhub_id,json=eventhubId,proto3" json:"eventhub_id,omitempty"`
 	// Deliver to an Azure Relay hybrid connection, by ARM ID (Relay is
 	// not yet a catalog kind -- pass the ID as a literal or an explicit
@@ -364,6 +368,10 @@ type AzureEventgridEventSubscriptionDestination struct {
 	// Deliver to a Service Bus topic, by ARM ID -- defaults to
 	// referencing an AzureServiceBusTopic's topic_id output. Set
 	// exactly one arm on this block.
+	//
+	// Events are DELIVERED into the topic; the subscription belongs to the
+	// Event Grid topic it subscribes to, so on a diagram the reference is
+	// access, not placement.
 	ServiceBusTopicId *v1.StringValueOrRef `protobuf:"bytes,5,opt,name=service_bus_topic_id,json=serviceBusTopicId,proto3" json:"service_bus_topic_id,omitempty"`
 	// Deliver to an Azure Storage queue. Set exactly one arm on this
 	// block.
@@ -1656,14 +1664,14 @@ const file_catalog_azure_azureeventgrideventsubscription_v1alpha1_spec_proto_raw
 	"<event_subscription_dead_letter_identity_requires_dead_letter\x12:dead_letter_identity requires dead_letter to be configured\x1a8!has(this.dead_letter_identity) || has(this.dead_letter)B\x18\n" +
 	"\x16_event_delivery_schemaB'\n" +
 	"%_advanced_filtering_on_arrays_enabledB\x16\n" +
-	"\x14_expiration_time_utc\"\xc1\v\n" +
+	"\x14_expiration_time_utc\"\xc9\v\n" +
 	"*AzureEventgridEventSubscriptionDestination\x12\x9a\x01\n" +
-	"\x0eazure_function\x18\x01 \x01(\v2s.dev.planton.azure.azureeventgrideventsubscription.v1alpha1.AzureEventgridEventSubscriptionAzureFunctionDestinationR\razureFunction\x12y\n" +
-	"\veventhub_id\x18\x02 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB$\x88\xd4a\x9d\x10\x92\xd4a\x1bstatus.outputs.event_hub_idR\n" +
+	"\x0eazure_function\x18\x01 \x01(\v2s.dev.planton.azure.azureeventgrideventsubscription.v1alpha1.AzureEventgridEventSubscriptionAzureFunctionDestinationR\razureFunction\x12}\n" +
+	"\veventhub_id\x18\x02 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB(\x88\xd4a\x9d\x10\x92\xd4a\x1bstatus.outputs.event_hub_id\x98\xd4a\x01R\n" +
 	"eventhubId\x12d\n" +
 	"\x14hybrid_connection_id\x18\x03 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefR\x12hybridConnectionId\x12\x85\x01\n" +
-	"\x14service_bus_queue_id\x18\x04 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB \x88\xd4a\x98\x10\x92\xd4a\x17status.outputs.queue_idR\x11serviceBusQueueId\x12\x85\x01\n" +
-	"\x14service_bus_topic_id\x18\x05 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB \x88\xd4a\x99\x10\x92\xd4a\x17status.outputs.topic_idR\x11serviceBusTopicId\x12\x97\x01\n" +
+	"\x14service_bus_queue_id\x18\x04 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB \x88\xd4a\x98\x10\x92\xd4a\x17status.outputs.queue_idR\x11serviceBusQueueId\x12\x89\x01\n" +
+	"\x14service_bus_topic_id\x18\x05 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB$\x88\xd4a\x99\x10\x92\xd4a\x17status.outputs.topic_id\x98\xd4a\x01R\x11serviceBusTopicId\x12\x97\x01\n" +
 	"\rstorage_queue\x18\x06 \x01(\v2r.dev.planton.azure.azureeventgrideventsubscription.v1alpha1.AzureEventgridEventSubscriptionStorageQueueDestinationR\fstorageQueue\x12\x87\x01\n" +
 	"\awebhook\x18\a \x01(\v2m.dev.planton.azure.azureeventgrideventsubscription.v1alpha1.AzureEventgridEventSubscriptionWebhookDestinationR\awebhook:\xe0\x03\xbaH\xdc\x03\x1a\xd9\x03\n" +
 	"*event_subscription_destination_exactly_one\x12\x9b\x01Set exactly one destination arm -- azure_function, eventhub_id, hybrid_connection_id, service_bus_queue_id, service_bus_topic_id, storage_queue, or webhook\x1a\x8c\x02(has(this.azure_function) ? 1 : 0) + (has(this.eventhub_id) ? 1 : 0) + (has(this.hybrid_connection_id) ? 1 : 0) + (has(this.service_bus_queue_id) ? 1 : 0) + (has(this.service_bus_topic_id) ? 1 : 0) + (has(this.storage_queue) ? 1 : 0) + (has(this.webhook) ? 1 : 0) == 1\"\xec\x02\n" +

--- a/catalog/azure/azureeventgrideventsubscription/v1alpha1/spec.proto
+++ b/catalog/azure/azureeventgrideventsubscription/v1alpha1/spec.proto
@@ -256,9 +256,14 @@ message AzureEventgridEventSubscriptionAzureFunctionDestination {
 message AzureEventgridEventSubscriptionStorageQueueDestination {
   // The storage account holding the queue, by ARM ID -- defaults to
   // referencing an AzureStorageAccount's storage_account_id output.
+  //
+  // Events are DELIVERED into a queue in this account; the subscription
+  // belongs to the topic it subscribes to, so on a diagram the reference is
+  // access, not placement.
   dev.planton.shared.foreignkey.v1.StringValueOrRef storage_account_id = 1 [
     (buf.validate.field).required = true,
     (dev.planton.shared.foreignkey.v1.default_kind) = AzureStorageAccount,
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true,
     (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.storage_account_id"
   ];
 
@@ -404,9 +409,14 @@ message AzureEventgridEventSubscriptionDeadLetter {
   // The storage account holding the dead-letter container, by ARM ID
   // -- defaults to referencing an AzureStorageAccount's
   // storage_account_id output.
+  //
+  // Dead-lettered events are WRITTEN into this account; the subscription
+  // belongs to the topic it subscribes to, so on a diagram the reference is
+  // access, not placement.
   dev.planton.shared.foreignkey.v1.StringValueOrRef storage_account_id = 1 [
     (buf.validate.field).required = true,
     (dev.planton.shared.foreignkey.v1.default_kind) = AzureStorageAccount,
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true,
     (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.storage_account_id"
   ];
 

--- a/catalog/azure/azureeventgrideventsubscription/v1alpha1/spec.proto
+++ b/catalog/azure/azureeventgrideventsubscription/v1alpha1/spec.proto
@@ -192,8 +192,13 @@ message AzureEventgridEventSubscriptionDestination {
   // Deliver to an Event Hub, by ARM ID -- defaults to referencing an
   // AzureEventHub's event_hub_id output. Set exactly one arm on this
   // block.
+  //
+  // Events are DELIVERED into the hub; the subscription belongs to the
+  // topic it subscribes to, so on a diagram the reference is access, not
+  // placement.
   dev.planton.shared.foreignkey.v1.StringValueOrRef eventhub_id = 2 [
     (dev.planton.shared.foreignkey.v1.default_kind) = AzureEventHub,
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true,
     (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.event_hub_id"
   ];
 
@@ -213,8 +218,13 @@ message AzureEventgridEventSubscriptionDestination {
   // Deliver to a Service Bus topic, by ARM ID -- defaults to
   // referencing an AzureServiceBusTopic's topic_id output. Set
   // exactly one arm on this block.
+  //
+  // Events are DELIVERED into the topic; the subscription belongs to the
+  // Event Grid topic it subscribes to, so on a diagram the reference is
+  // access, not placement.
   dev.planton.shared.foreignkey.v1.StringValueOrRef service_bus_topic_id = 5 [
     (dev.planton.shared.foreignkey.v1.default_kind) = AzureServiceBusTopic,
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true,
     (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.topic_id"
   ];
 

--- a/catalog/azure/azuremachinelearningworkspace/v1alpha1/spec.pb.go
+++ b/catalog/azure/azuremachinelearningworkspace/v1alpha1/spec.pb.go
@@ -304,6 +304,11 @@ type AzureMachineLearningWorkspaceSpec struct {
 	// built-in datastores, by ARM ID. Must be a general-purpose account
 	// WITHOUT hierarchical namespace (ARM rejects Data Lake Gen2
 	// accounts as default workspace storage). Fixed at creation.
+	//
+	// The workspace READS and WRITES this account as its default storage and
+	// lives in its own resource group, so on a diagram the reference is
+	// access, not placement -- the same rule its key_vault_id already
+	// carries.
 	StorageAccountId *v1.StringValueOrRef `protobuf:"bytes,6,opt,name=storage_account_id,json=storageAccountId,proto3" json:"storage_account_id,omitempty"`
 	// The workspace's managed identity. REQUIRED -- the workspace
 	// accesses its companion services (storage, key vault, insights)
@@ -1186,7 +1191,7 @@ var File_catalog_azure_azuremachinelearningworkspace_v1alpha1_spec_proto protore
 
 const file_catalog_azure_azuremachinelearningworkspace_v1alpha1_spec_proto_rawDesc = "" +
 	"\n" +
-	"?catalog/azure/azuremachinelearningworkspace/v1alpha1/spec.proto\x128dev.planton.azure.azuremachinelearningworkspace.v1alpha1\x1a\x1bbuf/validate/validate.proto\x1a&shared/foreignkey/v1/foreign_key.proto\x1a\x1cshared/options/options.proto\"\x90\"\n" +
+	"?catalog/azure/azuremachinelearningworkspace/v1alpha1/spec.proto\x128dev.planton.azure.azuremachinelearningworkspace.v1alpha1\x1a\x1bbuf/validate/validate.proto\x1a&shared/foreignkey/v1/foreign_key.proto\x1a\x1cshared/options/options.proto\"\x94\"\n" +
 	"!AzureMachineLearningWorkspaceSpec\x12\"\n" +
 	"\x06region\x18\x01 \x01(\tB\n" +
 	"\xbaH\a\xc8\x01\x01r\x02\x10\x01R\x06region\x12\x8c\x01\n" +
@@ -1194,8 +1199,8 @@ const file_catalog_azure_azuremachinelearningworkspace_v1alpha1_spec_proto_rawDe
 	"\x04name\x18\x03 \x01(\tB*\xbaH'\xc8\x01\x01r\"2 ^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$R\x04name\x12\xa1\x01\n" +
 	"\x17application_insights_id\x18\x04 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB5\xbaH\x03\xc8\x01\x01\x88\xd4a\x83\x10\x92\xd4a&status.outputs.application_insights_idR\x15applicationInsightsId\x12\x80\x01\n" +
 	"\fkey_vault_id\x18\x05 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB*\xbaH\x03\xc8\x01\x01\x88\xd4a\xd5\x0f\x92\xd4a\x1bstatus.outputs.key_vault_idR\n" +
-	"keyVaultId\x12\x92\x01\n" +
-	"\x12storage_account_id\x18\x06 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB0\xbaH\x03\xc8\x01\x01\x88\xd4a\xd9\x0f\x92\xd4a!status.outputs.storage_account_idR\x10storageAccountId\x12\x83\x01\n" +
+	"keyVaultId\x12\x96\x01\n" +
+	"\x12storage_account_id\x18\x06 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB4\xbaH\x03\xc8\x01\x01\x88\xd4a\xd9\x0f\x92\xd4a!status.outputs.storage_account_id\x98\xd4a\x01R\x10storageAccountId\x12\x83\x01\n" +
 	"\bidentity\x18\a \x01(\v2_.dev.planton.azure.azuremachinelearningworkspace.v1alpha1.AzureMachineLearningWorkspaceIdentityB\x06\xbaH\x03\xc8\x01\x01R\bidentity\x12o\n" +
 	"\x04kind\x18\b \x01(\x0e2[.dev.planton.azure.azuremachinelearningworkspace.v1alpha1.AzureMachineLearningWorkspaceKindR\x04kind\x12\x88\x01\n" +
 	"\rfeature_store\x18\t \x01(\v2c.dev.planton.azure.azuremachinelearningworkspace.v1alpha1.AzureMachineLearningWorkspaceFeatureStoreR\ffeatureStore\x12\x9c\x01\n" +

--- a/catalog/azure/azuremachinelearningworkspace/v1alpha1/spec.proto
+++ b/catalog/azure/azuremachinelearningworkspace/v1alpha1/spec.proto
@@ -79,9 +79,15 @@ message AzureMachineLearningWorkspaceSpec {
   // built-in datastores, by ARM ID. Must be a general-purpose account
   // WITHOUT hierarchical namespace (ARM rejects Data Lake Gen2
   // accounts as default workspace storage). Fixed at creation.
+  //
+  // The workspace READS and WRITES this account as its default storage and
+  // lives in its own resource group, so on a diagram the reference is
+  // access, not placement -- the same rule its key_vault_id already
+  // carries.
   dev.planton.shared.foreignkey.v1.StringValueOrRef storage_account_id = 6 [
     (buf.validate.field).required = true,
     (dev.planton.shared.foreignkey.v1.default_kind) = AzureStorageAccount,
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true,
     (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.storage_account_id"
   ];
 

--- a/catalog/azure/azuremonitordatacollectionrule/v1alpha1/spec.pb.go
+++ b/catalog/azure/azuremonitordatacollectionrule/v1alpha1/spec.pb.go
@@ -1619,6 +1619,10 @@ type AzureMonitorDataCollectionRuleEventHubDestination struct {
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	// The destination Event Hub, by ARM resource ID. Can be a literal
 	// ARM ID or a reference to an AzureEventHub output.
+	//
+	// Collected data is DELIVERED into the hub; the rule lives in its own
+	// resource group, so on a diagram the reference is access, not
+	// placement -- the diagnostic setting's rule.
 	EventHubId    *v1.StringValueOrRef `protobuf:"bytes,2,opt,name=event_hub_id,json=eventHubId,proto3" json:"event_hub_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -2192,11 +2196,11 @@ const file_catalog_azure_azuremonitordatacollectionrule_v1alpha1_spec_proto_rawD
 	"\x15workspace_resource_id\x18\x02 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB*\xbaH\x03\xc8\x01\x01\x88\xd4a\x82\x10\x92\xd4a\x1bstatus.outputs.workspace_idR\x13workspaceResourceId\"S\n" +
 	"1AzureMonitorDataCollectionRuleAzureMonitorMetrics\x12\x1e\n" +
 	"\x04name\x18\x01 \x01(\tB\n" +
-	"\xbaH\a\xc8\x01\x01r\x02\x10\x01R\x04name\"\xd6\x01\n" +
+	"\xbaH\a\xc8\x01\x01r\x02\x10\x01R\x04name\"\xda\x01\n" +
 	"1AzureMonitorDataCollectionRuleEventHubDestination\x12\x1e\n" +
 	"\x04name\x18\x01 \x01(\tB\n" +
-	"\xbaH\a\xc8\x01\x01r\x02\x10\x01R\x04name\x12\x80\x01\n" +
-	"\fevent_hub_id\x18\x02 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB*\xbaH\x03\xc8\x01\x01\x88\xd4a\x9d\x10\x92\xd4a\x1bstatus.outputs.event_hub_idR\n" +
+	"\xbaH\a\xc8\x01\x01r\x02\x10\x01R\x04name\x12\x84\x01\n" +
+	"\fevent_hub_id\x18\x02 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB.\xbaH\x03\xc8\x01\x01\x88\xd4a\x9d\x10\x92\xd4a\x1bstatus.outputs.event_hub_id\x98\xd4a\x01R\n" +
 	"eventHubId\"\xb8\x01\n" +
 	",AzureMonitorDataCollectionRuleMonitorAccount\x12\x1e\n" +
 	"\x04name\x18\x01 \x01(\tB\n" +

--- a/catalog/azure/azuremonitordatacollectionrule/v1alpha1/spec.pb.go
+++ b/catalog/azure/azuremonitordatacollectionrule/v1alpha1/spec.pb.go
@@ -1737,6 +1737,10 @@ type AzureMonitorDataCollectionRuleStorageBlobDestination struct {
 	ContainerName string `protobuf:"bytes,2,opt,name=container_name,json=containerName,proto3" json:"container_name,omitempty"`
 	// The destination storage account, by ARM resource ID. Can be a
 	// literal ARM ID or a reference to an AzureStorageAccount output.
+	//
+	// Collected data is DELIVERED into this account; the rule lives in its
+	// own resource group, so on a diagram the reference is access, not
+	// placement -- the diagnostic setting's rule.
 	StorageAccountId *v1.StringValueOrRef `protobuf:"bytes,3,opt,name=storage_account_id,json=storageAccountId,proto3" json:"storage_account_id,omitempty"`
 	unknownFields    protoimpl.UnknownFields
 	sizeCache        protoimpl.SizeCache
@@ -1802,6 +1806,10 @@ type AzureMonitorDataCollectionRuleStorageTableDirect struct {
 	TableName string `protobuf:"bytes,2,opt,name=table_name,json=tableName,proto3" json:"table_name,omitempty"`
 	// The destination storage account, by ARM resource ID. Can be a
 	// literal ARM ID or a reference to an AzureStorageAccount output.
+	//
+	// Collected data is DELIVERED into this account; the rule lives in its
+	// own resource group, so on a diagram the reference is access, not
+	// placement -- the diagnostic setting's rule.
 	StorageAccountId *v1.StringValueOrRef `protobuf:"bytes,3,opt,name=storage_account_id,json=storageAccountId,proto3" json:"storage_account_id,omitempty"`
 	unknownFields    protoimpl.UnknownFields
 	sizeCache        protoimpl.SizeCache
@@ -2193,20 +2201,20 @@ const file_catalog_azure_azuremonitordatacollectionrule_v1alpha1_spec_proto_rawD
 	",AzureMonitorDataCollectionRuleMonitorAccount\x12\x1e\n" +
 	"\x04name\x18\x01 \x01(\tB\n" +
 	"\xbaH\a\xc8\x01\x01r\x02\x10\x01R\x04name\x12h\n" +
-	"\x12monitor_account_id\x18\x02 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB\x06\xbaH\x03\xc8\x01\x01R\x10monitorAccountId\"\x9e\x02\n" +
+	"\x12monitor_account_id\x18\x02 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB\x06\xbaH\x03\xc8\x01\x01R\x10monitorAccountId\"\xa2\x02\n" +
 	"4AzureMonitorDataCollectionRuleStorageBlobDestination\x12\x1e\n" +
 	"\x04name\x18\x01 \x01(\tB\n" +
 	"\xbaH\a\xc8\x01\x01r\x02\x10\x01R\x04name\x121\n" +
 	"\x0econtainer_name\x18\x02 \x01(\tB\n" +
-	"\xbaH\a\xc8\x01\x01r\x02\x10\x01R\rcontainerName\x12\x92\x01\n" +
-	"\x12storage_account_id\x18\x03 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB0\xbaH\x03\xc8\x01\x01\x88\xd4a\xd9\x0f\x92\xd4a!status.outputs.storage_account_idR\x10storageAccountId\"\x92\x02\n" +
+	"\xbaH\a\xc8\x01\x01r\x02\x10\x01R\rcontainerName\x12\x96\x01\n" +
+	"\x12storage_account_id\x18\x03 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB4\xbaH\x03\xc8\x01\x01\x88\xd4a\xd9\x0f\x92\xd4a!status.outputs.storage_account_id\x98\xd4a\x01R\x10storageAccountId\"\x96\x02\n" +
 	"0AzureMonitorDataCollectionRuleStorageTableDirect\x12\x1e\n" +
 	"\x04name\x18\x01 \x01(\tB\n" +
 	"\xbaH\a\xc8\x01\x01r\x02\x10\x01R\x04name\x12)\n" +
 	"\n" +
 	"table_name\x18\x02 \x01(\tB\n" +
-	"\xbaH\a\xc8\x01\x01r\x02\x10\x01R\ttableName\x12\x92\x01\n" +
-	"\x12storage_account_id\x18\x03 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB0\xbaH\x03\xc8\x01\x01\x88\xd4a\xd9\x0f\x92\xd4a!status.outputs.storage_account_idR\x10storageAccountId\"\xfe\x01\n" +
+	"\xbaH\a\xc8\x01\x01r\x02\x10\x01R\ttableName\x12\x96\x01\n" +
+	"\x12storage_account_id\x18\x03 \x01(\v22.dev.planton.shared.foreignkey.v1.StringValueOrRefB4\xbaH\x03\xc8\x01\x01\x88\xd4a\xd9\x0f\x92\xd4a!status.outputs.storage_account_id\x98\xd4a\x01R\x10storageAccountId\"\xfe\x01\n" +
 	"&AzureMonitorDataCollectionRuleDataFlow\x12(\n" +
 	"\astreams\x18\x01 \x03(\tB\x0e\xbaH\v\x92\x01\b\b\x01\"\x04r\x02\x10\x01R\astreams\x122\n" +
 	"\fdestinations\x18\x02 \x03(\tB\x0e\xbaH\v\x92\x01\b\b\x01\"\x04r\x02\x10\x01R\fdestinations\x12,\n" +

--- a/catalog/azure/azuremonitordatacollectionrule/v1alpha1/spec.proto
+++ b/catalog/azure/azuremonitordatacollectionrule/v1alpha1/spec.proto
@@ -754,9 +754,14 @@ message AzureMonitorDataCollectionRuleStorageBlobDestination {
 
   // The destination storage account, by ARM resource ID. Can be a
   // literal ARM ID or a reference to an AzureStorageAccount output.
+  //
+  // Collected data is DELIVERED into this account; the rule lives in its
+  // own resource group, so on a diagram the reference is access, not
+  // placement -- the diagnostic setting's rule.
   dev.planton.shared.foreignkey.v1.StringValueOrRef storage_account_id = 3 [
     (buf.validate.field).required = true,
     (dev.planton.shared.foreignkey.v1.default_kind) = AzureStorageAccount,
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true,
     (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.storage_account_id"
   ];
 }
@@ -777,9 +782,14 @@ message AzureMonitorDataCollectionRuleStorageTableDirect {
 
   // The destination storage account, by ARM resource ID. Can be a
   // literal ARM ID or a reference to an AzureStorageAccount output.
+  //
+  // Collected data is DELIVERED into this account; the rule lives in its
+  // own resource group, so on a diagram the reference is access, not
+  // placement -- the diagnostic setting's rule.
   dev.planton.shared.foreignkey.v1.StringValueOrRef storage_account_id = 3 [
     (buf.validate.field).required = true,
     (dev.planton.shared.foreignkey.v1.default_kind) = AzureStorageAccount,
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true,
     (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.storage_account_id"
   ];
 }

--- a/catalog/azure/azuremonitordatacollectionrule/v1alpha1/spec.proto
+++ b/catalog/azure/azuremonitordatacollectionrule/v1alpha1/spec.proto
@@ -714,9 +714,14 @@ message AzureMonitorDataCollectionRuleEventHubDestination {
 
   // The destination Event Hub, by ARM resource ID. Can be a literal
   // ARM ID or a reference to an AzureEventHub output.
+  //
+  // Collected data is DELIVERED into the hub; the rule lives in its own
+  // resource group, so on a diagram the reference is access, not
+  // placement -- the diagnostic setting's rule.
   dev.planton.shared.foreignkey.v1.StringValueOrRef event_hub_id = 2 [
     (buf.validate.field).required = true,
     (dev.planton.shared.foreignkey.v1.default_kind) = AzureEventHub,
+    (dev.planton.shared.foreignkey.v1.containment_exempt) = true,
     (dev.planton.shared.foreignkey.v1.default_kind_field_path) = "status.outputs.event_hub_id"
   ];
 }

--- a/shared/cloudresourcekind/testdata/containment_decisions.txt
+++ b/shared/cloudresourcekind/testdata/containment_decisions.txt
@@ -188,8 +188,6 @@ contained dev.planton.azure.azurednsrecord.v1alpha1.AzureDnsRecordSpec.resource_
 contained dev.planton.azure.azurednsrecord.v1alpha1.AzureDnsRecordSpec.zone_name -> AzureDnsZone
 contained dev.planton.azure.azurednszone.v1alpha1.AzureDnsZoneSpec.resource_group -> AzureResourceGroup
 contained dev.planton.azure.azureeventgriddomain.v1alpha1.AzureEventgridDomainSpec.resource_group -> AzureResourceGroup
-contained dev.planton.azure.azureeventgrideventsubscription.v1alpha1.AzureEventgridEventSubscriptionDestination.eventhub_id -> AzureEventHub
-contained dev.planton.azure.azureeventgrideventsubscription.v1alpha1.AzureEventgridEventSubscriptionDestination.service_bus_topic_id -> AzureServiceBusTopic
 contained dev.planton.azure.azureeventgridnamespace.v1alpha1.AzureEventgridNamespaceSpec.resource_group -> AzureResourceGroup
 contained dev.planton.azure.azureeventgridsystemtopic.v1alpha1.AzureEventgridSystemTopicSpec.resource_group -> AzureResourceGroup
 contained dev.planton.azure.azureeventgridtopic.v1alpha1.AzureEventgridTopicSpec.resource_group -> AzureResourceGroup
@@ -246,7 +244,6 @@ contained dev.planton.azure.azuremongocluster.v1alpha1.AzureMongoClusterSpec.res
 contained dev.planton.azure.azuremonitoractiongroup.v1alpha1.AzureMonitorActionGroupSpec.resource_group -> AzureResourceGroup
 contained dev.planton.azure.azuremonitoractivitylogalert.v1alpha1.AzureMonitorActivityLogAlertSpec.resource_group -> AzureResourceGroup
 contained dev.planton.azure.azuremonitorautoscalesetting.v1alpha1.AzureMonitorAutoscaleSettingSpec.resource_group -> AzureResourceGroup
-contained dev.planton.azure.azuremonitordatacollectionrule.v1alpha1.AzureMonitorDataCollectionRuleEventHubDestination.event_hub_id -> AzureEventHub
 contained dev.planton.azure.azuremonitordatacollectionrule.v1alpha1.AzureMonitorDataCollectionRuleSpec.resource_group -> AzureResourceGroup
 contained dev.planton.azure.azuremonitormetricalert.v1alpha1.AzureMonitorMetricAlertSpec.resource_group -> AzureResourceGroup
 contained dev.planton.azure.azuremonitorscheduledqueryalert.v1alpha1.AzureMonitorScheduledQueryAlertSpec.resource_group -> AzureResourceGroup
@@ -684,6 +681,8 @@ exempt    dev.planton.azure.azuredatafactorylinkedservice.v1alpha1.AzureDataFact
 exempt    dev.planton.azure.azuredatafactorylinkedservice.v1alpha1.AzureDataFactoryLinkedServiceDataLakeStorageGen2.url -> AzureStorageAccount
 exempt    dev.planton.azure.azuredatafactorytrigger.v1alpha1.AzureDataFactoryTriggerBlobEvent.storage_account_id -> AzureStorageAccount
 exempt    dev.planton.azure.azureeventgrideventsubscription.v1alpha1.AzureEventgridEventSubscriptionDeadLetter.storage_account_id -> AzureStorageAccount
+exempt    dev.planton.azure.azureeventgrideventsubscription.v1alpha1.AzureEventgridEventSubscriptionDestination.eventhub_id -> AzureEventHub
+exempt    dev.planton.azure.azureeventgrideventsubscription.v1alpha1.AzureEventgridEventSubscriptionDestination.service_bus_topic_id -> AzureServiceBusTopic
 exempt    dev.planton.azure.azureeventgrideventsubscription.v1alpha1.AzureEventgridEventSubscriptionStorageQueueDestination.storage_account_id -> AzureStorageAccount
 exempt    dev.planton.azure.azureeventhub.v1alpha1.AzureEventHubCaptureDestination.storage_account_id -> AzureStorageAccount
 exempt    dev.planton.azure.azureeventhubdisasterrecoveryconfig.v1alpha1.AzureEventHubDisasterRecoveryConfigSpec.partner_namespace_id -> AzureEventHubNamespace
@@ -710,6 +709,7 @@ exempt    dev.planton.azure.azuremachinelearningworkspace.v1alpha1.AzureMachineL
 exempt    dev.planton.azure.azuremonitoractiongroup.v1alpha1.AzureMonitorActionGroupEventHubReceiver.event_hub_name -> AzureEventHub
 exempt    dev.planton.azure.azuremonitoractiongroup.v1alpha1.AzureMonitorActionGroupEventHubReceiver.event_hub_namespace -> AzureEventHubNamespace
 exempt    dev.planton.azure.azuremonitoractivitylogalert.v1alpha1.AzureMonitorActivityLogAlertSpec.scopes -> AzureResourceGroup
+exempt    dev.planton.azure.azuremonitordatacollectionrule.v1alpha1.AzureMonitorDataCollectionRuleEventHubDestination.event_hub_id -> AzureEventHub
 exempt    dev.planton.azure.azuremonitordatacollectionrule.v1alpha1.AzureMonitorDataCollectionRuleStorageBlobDestination.storage_account_id -> AzureStorageAccount
 exempt    dev.planton.azure.azuremonitordatacollectionrule.v1alpha1.AzureMonitorDataCollectionRuleStorageTableDirect.storage_account_id -> AzureStorageAccount
 exempt    dev.planton.azure.azuremonitordiagnosticsetting.v1alpha1.AzureMonitorDiagnosticSettingSpec.eventhub_name -> AzureEventHub

--- a/shared/cloudresourcekind/testdata/containment_decisions.txt
+++ b/shared/cloudresourcekind/testdata/containment_decisions.txt
@@ -113,7 +113,6 @@ contained dev.planton.aws.awsvpcpeering.v1alpha1.AwsVpcPeeringRequest.vpc_id -> 
 contained dev.planton.azure.azureaifoundry.v1alpha1.AzureAiFoundryEncryption.key_vault_id -> AzureKeyVault
 contained dev.planton.azure.azureaifoundry.v1alpha1.AzureAiFoundrySpec.key_vault_id -> AzureKeyVault
 contained dev.planton.azure.azureaifoundry.v1alpha1.AzureAiFoundrySpec.resource_group -> AzureResourceGroup
-contained dev.planton.azure.azureaifoundry.v1alpha1.AzureAiFoundrySpec.storage_account_id -> AzureStorageAccount
 contained dev.planton.azure.azureakscluster.v1alpha1.AzureAksClusterApiServerAccessProfile.subnet_id -> AzureSubnet
 contained dev.planton.azure.azureakscluster.v1alpha1.AzureAksClusterDefaultNodePool.pod_subnet_id -> AzureSubnet
 contained dev.planton.azure.azureakscluster.v1alpha1.AzureAksClusterDefaultNodePool.vnet_subnet_id -> AzureSubnet
@@ -131,7 +130,6 @@ contained dev.planton.azure.azureapplicationinsightsstandardwebtest.v1alpha1.Azu
 contained dev.planton.azure.azureapplicationsecuritygroup.v1alpha1.AzureApplicationSecurityGroupSpec.resource_group -> AzureResourceGroup
 contained dev.planton.azure.azureavailabilityset.v1alpha1.AzureAvailabilitySetSpec.resource_group -> AzureResourceGroup
 contained dev.planton.azure.azurebackupcontainerstorageaccount.v1alpha1.AzureBackupContainerStorageAccountSpec.resource_group -> AzureResourceGroup
-contained dev.planton.azure.azurebackupcontainerstorageaccount.v1alpha1.AzureBackupContainerStorageAccountSpec.storage_account_id -> AzureStorageAccount
 contained dev.planton.azure.azurebackuppolicyfileshare.v1alpha1.AzureBackupPolicyFileShareSpec.resource_group -> AzureResourceGroup
 contained dev.planton.azure.azurebackuppolicyvm.v1alpha1.AzureBackupPolicyVmSpec.resource_group -> AzureResourceGroup
 contained dev.planton.azure.azurebackupprotectedfileshare.v1alpha1.AzureBackupProtectedFileShareSpec.resource_group -> AzureResourceGroup
@@ -141,7 +139,6 @@ contained dev.planton.azure.azurebastionhost.v1alpha1.AzureBastionHostSpec.resou
 contained dev.planton.azure.azurebastionhost.v1alpha1.AzureBastionHostSpec.virtual_network_id -> AzureVirtualNetwork
 contained dev.planton.azure.azurecognitiveaccount.v1alpha1.AzureCognitiveAccountNetworkInjection.subnet_id -> AzureSubnet
 contained dev.planton.azure.azurecognitiveaccount.v1alpha1.AzureCognitiveAccountSpec.resource_group -> AzureResourceGroup
-contained dev.planton.azure.azurecognitiveaccount.v1alpha1.AzureCognitiveAccountStorage.storage_account_id -> AzureStorageAccount
 contained dev.planton.azure.azurecognitiveaccount.v1alpha1.AzureCognitiveAccountVirtualNetworkRule.subnet_id -> AzureSubnet
 contained dev.planton.azure.azurecomputegallery.v1alpha1.AzureComputeGallerySpec.resource_group -> AzureResourceGroup
 contained dev.planton.azure.azurecomputegalleryimage.v1alpha1.AzureComputeGalleryImageSpec.resource_group -> AzureResourceGroup
@@ -174,10 +171,7 @@ contained dev.planton.azure.azuredatafactory.v1alpha1.AzureDataFactorySpec.resou
 contained dev.planton.azure.azuredatafactoryintegrationruntime.v1alpha1.AzureDataFactoryIntegrationRuntimeSsisExpressVnetIntegration.subnet_id -> AzureSubnet
 contained dev.planton.azure.azuredatafactoryintegrationruntime.v1alpha1.AzureDataFactoryIntegrationRuntimeSsisVnetIntegration.subnet_id -> AzureSubnet
 contained dev.planton.azure.azuredatafactoryintegrationruntime.v1alpha1.AzureDataFactoryIntegrationRuntimeSsisVnetIntegration.vnet_id -> AzureVirtualNetwork
-contained dev.planton.azure.azuredatafactorylinkedservice.v1alpha1.AzureDataFactoryLinkedServiceAzureBlobStorage.service_endpoint -> AzureStorageAccount
-contained dev.planton.azure.azuredatafactorylinkedservice.v1alpha1.AzureDataFactoryLinkedServiceDataLakeStorageGen2.url -> AzureStorageAccount
 contained dev.planton.azure.azuredatafactorylinkedservice.v1alpha1.AzureDataFactoryLinkedServiceKeyVault.key_vault_id -> AzureKeyVault
-contained dev.planton.azure.azuredatafactorytrigger.v1alpha1.AzureDataFactoryTriggerBlobEvent.storage_account_id -> AzureStorageAccount
 contained dev.planton.azure.azuredataprotectionbackupinstance.v1alpha1.AzureDataProtectionBackupInstanceBlobStorage.storage_account_id -> AzureStorageAccount
 contained dev.planton.azure.azuredataprotectionbackupinstance.v1alpha1.AzureDataProtectionBackupInstanceDataLakeStorage.storage_account_id -> AzureStorageAccount
 contained dev.planton.azure.azuredataprotectionbackupinstance.v1alpha1.AzureDataProtectionBackupInstanceDisk.snapshot_resource_group_name -> AzureResourceGroup
@@ -194,10 +188,8 @@ contained dev.planton.azure.azurednsrecord.v1alpha1.AzureDnsRecordSpec.resource_
 contained dev.planton.azure.azurednsrecord.v1alpha1.AzureDnsRecordSpec.zone_name -> AzureDnsZone
 contained dev.planton.azure.azurednszone.v1alpha1.AzureDnsZoneSpec.resource_group -> AzureResourceGroup
 contained dev.planton.azure.azureeventgriddomain.v1alpha1.AzureEventgridDomainSpec.resource_group -> AzureResourceGroup
-contained dev.planton.azure.azureeventgrideventsubscription.v1alpha1.AzureEventgridEventSubscriptionDeadLetter.storage_account_id -> AzureStorageAccount
 contained dev.planton.azure.azureeventgrideventsubscription.v1alpha1.AzureEventgridEventSubscriptionDestination.eventhub_id -> AzureEventHub
 contained dev.planton.azure.azureeventgrideventsubscription.v1alpha1.AzureEventgridEventSubscriptionDestination.service_bus_topic_id -> AzureServiceBusTopic
-contained dev.planton.azure.azureeventgrideventsubscription.v1alpha1.AzureEventgridEventSubscriptionStorageQueueDestination.storage_account_id -> AzureStorageAccount
 contained dev.planton.azure.azureeventgridnamespace.v1alpha1.AzureEventgridNamespaceSpec.resource_group -> AzureResourceGroup
 contained dev.planton.azure.azureeventgridsystemtopic.v1alpha1.AzureEventgridSystemTopicSpec.resource_group -> AzureResourceGroup
 contained dev.planton.azure.azureeventgridtopic.v1alpha1.AzureEventgridTopicSpec.resource_group -> AzureResourceGroup
@@ -248,7 +240,6 @@ contained dev.planton.azure.azuremachinelearningworkspace.v1alpha1.AzureMachineL
 contained dev.planton.azure.azuremachinelearningworkspace.v1alpha1.AzureMachineLearningWorkspaceServerlessCompute.subnet_id -> AzureSubnet
 contained dev.planton.azure.azuremachinelearningworkspace.v1alpha1.AzureMachineLearningWorkspaceSpec.key_vault_id -> AzureKeyVault
 contained dev.planton.azure.azuremachinelearningworkspace.v1alpha1.AzureMachineLearningWorkspaceSpec.resource_group -> AzureResourceGroup
-contained dev.planton.azure.azuremachinelearningworkspace.v1alpha1.AzureMachineLearningWorkspaceSpec.storage_account_id -> AzureStorageAccount
 contained dev.planton.azure.azuremanageddisk.v1alpha1.AzureManagedDiskSpec.resource_group -> AzureResourceGroup
 contained dev.planton.azure.azuremanagedredis.v1alpha1.AzureManagedRedisSpec.resource_group -> AzureResourceGroup
 contained dev.planton.azure.azuremongocluster.v1alpha1.AzureMongoClusterSpec.resource_group -> AzureResourceGroup
@@ -257,8 +248,6 @@ contained dev.planton.azure.azuremonitoractivitylogalert.v1alpha1.AzureMonitorAc
 contained dev.planton.azure.azuremonitorautoscalesetting.v1alpha1.AzureMonitorAutoscaleSettingSpec.resource_group -> AzureResourceGroup
 contained dev.planton.azure.azuremonitordatacollectionrule.v1alpha1.AzureMonitorDataCollectionRuleEventHubDestination.event_hub_id -> AzureEventHub
 contained dev.planton.azure.azuremonitordatacollectionrule.v1alpha1.AzureMonitorDataCollectionRuleSpec.resource_group -> AzureResourceGroup
-contained dev.planton.azure.azuremonitordatacollectionrule.v1alpha1.AzureMonitorDataCollectionRuleStorageBlobDestination.storage_account_id -> AzureStorageAccount
-contained dev.planton.azure.azuremonitordatacollectionrule.v1alpha1.AzureMonitorDataCollectionRuleStorageTableDirect.storage_account_id -> AzureStorageAccount
 contained dev.planton.azure.azuremonitormetricalert.v1alpha1.AzureMonitorMetricAlertSpec.resource_group -> AzureResourceGroup
 contained dev.planton.azure.azuremonitorscheduledqueryalert.v1alpha1.AzureMonitorScheduledQueryAlertSpec.resource_group -> AzureResourceGroup
 contained dev.planton.azure.azuremssqldatabase.v1alpha1.AzureMssqlDatabaseSpec.server_id -> AzureMssqlServer
@@ -682,12 +671,20 @@ exempt    dev.planton.aws.awsroute53zone.v1alpha1.AwsRoute53ZoneVpcAssociation.v
 exempt    dev.planton.aws.awssagemakerdomain.v1alpha1.AwsSagemakerDomainEfsFileSystemConfig.file_system_id -> AwsElasticFileSystem
 exempt    dev.planton.aws.awssesconfigurationset.v1alpha1.AwsSesConfigurationSetEventDestination.event_bus -> AwsEventBridgeBus
 exempt    dev.planton.aws.awsvpcendpoint.v1alpha1.AwsVpcEndpointSpec.route_table_ids -> AwsSubnet
+exempt    dev.planton.azure.azureaifoundry.v1alpha1.AzureAiFoundrySpec.storage_account_id -> AzureStorageAccount
 exempt    dev.planton.azure.azureakscluster.v1alpha1.AzureAksClusterServiceMeshCertificateAuthority.key_vault_id -> AzureKeyVault
 exempt    dev.planton.azure.azureakscluster.v1alpha1.AzureAksClusterSpec.private_dns_zone_id -> AzurePrivateDnsZone
 exempt    dev.planton.azure.azureakscluster.v1alpha1.AzureAksClusterWebAppRouting.dns_zone_ids -> AzureDnsZone
+exempt    dev.planton.azure.azurebackupcontainerstorageaccount.v1alpha1.AzureBackupContainerStorageAccountSpec.storage_account_id -> AzureStorageAccount
+exempt    dev.planton.azure.azurecognitiveaccount.v1alpha1.AzureCognitiveAccountStorage.storage_account_id -> AzureStorageAccount
 exempt    dev.planton.azure.azurecontainerappenvironmentstorage.v1alpha1.AzureContainerAppEnvironmentStorageSpec.access_key -> AzureStorageAccount
 exempt    dev.planton.azure.azurecontainerappenvironmentstorage.v1alpha1.AzureContainerAppEnvironmentStorageSpec.account_name -> AzureStorageAccount
 exempt    dev.planton.azure.azurecosmosdbaccount.v1alpha1.AzureCosmosdbAccountVirtualNetworkRule.subnet_id -> AzureSubnet
+exempt    dev.planton.azure.azuredatafactorylinkedservice.v1alpha1.AzureDataFactoryLinkedServiceAzureBlobStorage.service_endpoint -> AzureStorageAccount
+exempt    dev.planton.azure.azuredatafactorylinkedservice.v1alpha1.AzureDataFactoryLinkedServiceDataLakeStorageGen2.url -> AzureStorageAccount
+exempt    dev.planton.azure.azuredatafactorytrigger.v1alpha1.AzureDataFactoryTriggerBlobEvent.storage_account_id -> AzureStorageAccount
+exempt    dev.planton.azure.azureeventgrideventsubscription.v1alpha1.AzureEventgridEventSubscriptionDeadLetter.storage_account_id -> AzureStorageAccount
+exempt    dev.planton.azure.azureeventgrideventsubscription.v1alpha1.AzureEventgridEventSubscriptionStorageQueueDestination.storage_account_id -> AzureStorageAccount
 exempt    dev.planton.azure.azureeventhub.v1alpha1.AzureEventHubCaptureDestination.storage_account_id -> AzureStorageAccount
 exempt    dev.planton.azure.azureeventhubdisasterrecoveryconfig.v1alpha1.AzureEventHubDisasterRecoveryConfigSpec.partner_namespace_id -> AzureEventHubNamespace
 exempt    dev.planton.azure.azureeventhubnamespace.v1alpha1.AzureEventHubNamespaceVirtualNetworkRule.subnet_id -> AzureSubnet
@@ -709,9 +706,12 @@ exempt    dev.planton.azure.azurelinuxwebapp.v1alpha1.AzureLinuxWebAppIpRestrict
 exempt    dev.planton.azure.azurelinuxwebapp.v1alpha1.AzureLinuxWebAppIpRestrictionHeaders.x_azure_fdid -> AzureFrontDoorProfile
 exempt    dev.planton.azure.azurelinuxwebapp.v1alpha1.AzureLinuxWebAppSpec.virtual_network_subnet_id -> AzureSubnet
 exempt    dev.planton.azure.azurelinuxwebapp.v1alpha1.AzureLinuxWebAppStorageMount.access_key -> AzureStorageAccount
+exempt    dev.planton.azure.azuremachinelearningworkspace.v1alpha1.AzureMachineLearningWorkspaceSpec.storage_account_id -> AzureStorageAccount
 exempt    dev.planton.azure.azuremonitoractiongroup.v1alpha1.AzureMonitorActionGroupEventHubReceiver.event_hub_name -> AzureEventHub
 exempt    dev.planton.azure.azuremonitoractiongroup.v1alpha1.AzureMonitorActionGroupEventHubReceiver.event_hub_namespace -> AzureEventHubNamespace
 exempt    dev.planton.azure.azuremonitoractivitylogalert.v1alpha1.AzureMonitorActivityLogAlertSpec.scopes -> AzureResourceGroup
+exempt    dev.planton.azure.azuremonitordatacollectionrule.v1alpha1.AzureMonitorDataCollectionRuleStorageBlobDestination.storage_account_id -> AzureStorageAccount
+exempt    dev.planton.azure.azuremonitordatacollectionrule.v1alpha1.AzureMonitorDataCollectionRuleStorageTableDirect.storage_account_id -> AzureStorageAccount
 exempt    dev.planton.azure.azuremonitordiagnosticsetting.v1alpha1.AzureMonitorDiagnosticSettingSpec.eventhub_name -> AzureEventHub
 exempt    dev.planton.azure.azuremonitordiagnosticsetting.v1alpha1.AzureMonitorDiagnosticSettingSpec.storage_account_id -> AzureStorageAccount
 exempt    dev.planton.azure.azuremssqlserver.v1alpha1.AzureMssqlServerVirtualNetworkRule.subnet_id -> AzureSubnet


### PR DESCRIPTION
## What changed

**Second commit (same files, same rule):** three delivery destinations become `containment_exempt` -- an Event Grid subscription's `…Destination.eventhub_id` and `…Destination.service_bus_topic_id`, and a data collection rule's `…EventHubDestination.event_hub_id`. A subscription belongs to the Event Grid topic it subscribes to and a rule to its own resource group; the event hub and the Service Bus topic are container kinds (consumer groups and subscriptions are created into them), so a deliverer was drawn INSIDE the stream it delivers into. Three more golden lines `contained → exempt`; fourteen in all.

**First commit:** eleven references INTO `AzureStorageAccount` become `containment_exempt`, each with its reason in the field comment:

| Kind | Field | What it does with the account |
|---|---|---|
| AI Foundry hub | `AzureAiFoundrySpec.storage_account_id` | default workspace storage (its `key_vault_id` already carries the exemption) |
| Machine Learning workspace | `AzureMachineLearningWorkspaceSpec.storage_account_id` | default workspace storage (same) |
| Cognitive Services account | `AzureCognitiveAccountStorage.storage_account_id` | training data |
| Data Factory linked service | `…AzureBlobStorage.service_endpoint`, `…DataLakeStorageGen2.url` | the factory's connection to a store |
| Data Factory trigger | `…BlobEvent.storage_account_id` | listens to blob events |
| Event Grid subscription | `…DeadLetter.storage_account_id`, `…StorageQueueDestination.storage_account_id` | dead-letters into / delivers into a queue in |
| Data collection rule | `…StorageBlobDestination.storage_account_id`, `…StorageTableDirect.storage_account_id` | delivers collected data into |
| Recovery Services backup container | `AzureBackupContainerStorageAccountSpec.storage_account_id` | registers the account with a vault (an ARM child of the vault) |

The containment golden moves exactly fourteen lines `contained → exempt` across the two commits; nothing else moved. Go stubs regenerated with the pinned `protoc-gen-go v1.36.6` (comments and option bytes only).

## Why

The storage account is a container kind (its containers, shares, queues, tables, filesystems, encryption scopes, and local users are created into it). Without the exemption, every one of these consumers was drawn INSIDE the storage account it merely uses -- a workspace inside its default storage, a monitoring rule inside the account it delivers to. The flow log (#537), the diagnostic setting, the Event Hub capture destination, and the web apps' storage already carry the same exemption for the same reason.

Seven of the eleven kinds name their resource group and stand there after this change. The Data Factory linked service and trigger and the Event Grid subscription name only their factory or topic, which the catalog does not yet mark containers; after this change they stand outside every room rather than inside a storage account, until their parents are marked -- a reach exempted now stays correct then.

## How to check

```bash
go test ./shared/cloudresourcekind/... -run TestContainmentDecisions
grep -rn containment_exempt catalog/azure/azureaifoundry catalog/azure/azurecognitiveaccount catalog/azure/azuredatafactorylinkedservice catalog/azure/azuredatafactorytrigger catalog/azure/azureeventgrideventsubscription catalog/azure/azuremachinelearningworkspace catalog/azure/azuremonitordatacollectionrule catalog/azure/azurebackupcontainerstorageaccount --include=spec.proto
```

No overlap with any open pull request (#531–#543): none of them touches these eight spec files.
